### PR TITLE
Followup to 5e0be20: Obey "Maximum transport distance in turns"

### DIFF
--- a/src/rotp/model/ai/AI.java
+++ b/src/rotp/model/ai/AI.java
@@ -258,6 +258,9 @@ public class AI implements Base {
 
         Collections.sort(needy,TRANSPORT_PRIORITY);
 
+        float allowableTurns = (float) (1 + Math.min(7, Math.floor(22 / empire.tech().topSpeed())));
+        if(empire.isPlayerControlled())
+            allowableTurns = Math.min(session().getGovernorOptions().getTransportMaxTurns(), allowableTurns);
         for(ColonyTransporter needer : needy)
         {
             TARGET_COLONY = needer;
@@ -268,7 +271,6 @@ public class AI implements Base {
                 if(giver.colony.transport().size() > 0)
                     continue;
                 allGiversBusy = false;
-                float allowableTurns = (float) (1 + Math.min(7, Math.floor(22 / empire.tech().topSpeed())));
                 float travelTime = giver.colony.transport().travelTime(needer.colony.starSystem());
                 if ((giver.maxPopToGive >= minTransportSize) && (giver.transportPriority < needer.transportPriority)
                         && travelTime <= allowableTurns) {


### PR DESCRIPTION
This takes into account the "Maximum transport distance in turns"-governor-option when "Let AI handle population transportation" is enabled. (cf 5e0be20)

(I have absolutely no idea what I'm doing. I haven't run the test suite, or rather, if there is a test suite, I haven't found it. But when building and running the jar locally, it works.)