### PR TITLE
Bring back old normalPopGrowth() functionality via Planet

### DIFF
--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -1007,21 +1007,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
     public float maxUseableFactories() {
         return workingPopulation() * empire().maxRobotControls();
     }
-    public float normalPopGrowth() {
-    	// calculate growth rate based on current pop, environment & race
-    	float workingPopulation = (workingPopulation());
-        float maxNewPopulation = planet.currentSize() - workingPopulation;
-        float baseGrowthRate = max(0, (1 - (workingPopulation / planet.currentSize())) / 10);
-        baseGrowthRate *= empire.growthRateMod();
-        if (!empire.ignoresPlanetEnvironment())
-            baseGrowthRate *= planet.growthAdj();
-
-        // always at least .1 base growth in pop
-        float newGrownPopulation = max(.1f, workingPopulation * baseGrowthRate);
-        newGrownPopulation = min(newGrownPopulation, maxNewPopulation);
-
-        return newGrownPopulation;
-    }
+    public float normalPopGrowth() { return planet.normalPopGrowth(workingPopulation()); }
     public ShipFleet homeFleet() {
         return starSystem().orbitingFleetForEmpire(empire());
     }

--- a/src/rotp/model/planet/Planet.java
+++ b/src/rotp/model/planet/Planet.java
@@ -431,6 +431,23 @@ public class Planet implements Base, IMappedObject, Serializable {
 
         return size;
     }
+    public float normalPopGrowth(float currentPopulation) { return normalPopGrowth(currentPopulation, empire()); }
+    public float normalPopGrowth(float currentPopulation, Empire civ) {
+        float maxNewPopulation = currentSize() - currentPopulation;
+        float baseGrowthRate = max(0, (1 - (currentPopulation / currentSize())) / 10);
+        if (civ != null) {
+            baseGrowthRate *= civ.growthRateMod();
+            if (!civ.ignoresPlanetEnvironment())
+                baseGrowthRate *= growthAdj();
+        }
+
+        // always at least .1 base growth in pop
+        float newGrownPopulation = max(.1f, currentPopulation * baseGrowthRate);
+        newGrownPopulation = min(newGrownPopulation, maxNewPopulation);
+
+        return newGrownPopulation;
+    }
+
     private void initColors() {
         switch(type().key()) {
             case PlanetType.OCEAN:


### PR DESCRIPTION
Ah, hmm, looks like https://github.com/BrokenRegistry/Rotp-Fusion/commit/45e2d1e0b23ac129e7e56774dddd0fd61176789a just removed the `normalPopGrowth(int toSend)` that https://github.com/BrokenRegistry/Rotp-Fusion/pull/5 uses. I'm assuming you have your reasons for not wanting it in Colony, but what about allowing Planet to do something similar?

Making a separate pull request for this to make it easier to see that this doesn't change any functionality (this is a very dangerous operation, since `normalPopGrowth()` is the actual function that determines real population growth when `nextTurn()` is called). This solely relocates the code and has the Colony just pass its population (thereby allowing passing a different, expected population).