### PR TITLE
Show alienFactories on planet

### DIFF
--- a/src/rotp/ui/main/SystemPanel.java
+++ b/src/rotp/ui/main/SystemPanel.java
@@ -246,7 +246,7 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
         if (player().sv.isColonized(sys.id))
             drawSystemTreatyStatus(g, sys, f, y, w, lineH);
 
-        if (showTransports) {
+        { // block to limit scope of variables
         	boolean isPlayer = isPlayer(sys.empire());
             int y0 = s54;
             int x0 = s25;

--- a/src/rotp/ui/main/SystemPanel.java
+++ b/src/rotp/ui/main/SystemPanel.java
@@ -284,7 +284,7 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
                 // just as we show the player the planet's current terraformed size.
                 for (int empId=0; empId<sys.galaxy().numEmpires(); empId++)
                     if (sys.planet().alienFactories(empId) > 0) {
-                        str = sys.planet().alienFactories(empId).toString() + ' ' + sys.galaxy().empire(empId).name();
+                        str = String.valueOf(sys.planet().alienFactories(empId)) + ' ' + sys.galaxy().empire(empId).name();
                         g.setColor(sys.galaxy().empire(empId).nameColor());
                         drawString(g, str, x0, y0);
                         sw = g.getFontMetrics().stringWidth(str);

--- a/src/rotp/ui/main/SystemPanel.java
+++ b/src/rotp/ui/main/SystemPanel.java
@@ -278,7 +278,8 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
             		drawString(g, str, x0, y0);
             	}
                 if (friendPop > 0 || enemyPop > 0)
-                    y0 -= lineH;
+                    y0 += lineH;
+                x0 = s25;
                 // This will only display alienFactories if the player has colonized the system.
                 // We could display alienFactories if the player has merely explored the system,
                 // just as we show the player the planet's current terraformed size.

--- a/src/rotp/ui/main/SystemPanel.java
+++ b/src/rotp/ui/main/SystemPanel.java
@@ -211,7 +211,7 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
         int y = startY;
 
         int lines = showSpyData ? 5 : 4;
-        int lineH = h/lines;
+        int lineH = h/lines;  // line height
 
         // ensure we are always at least font 16, readjust lineH to compensate
         int estFontSize = min(20, max(16, unscaled(lineH)));
@@ -277,6 +277,19 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
             		g.setColor(Color.red);
             		drawString(g, str, x0, y0);
             	}
+                if (friendPop > 0 || enemyPop > 0)
+                    y0 -= lineH;
+                // This will only display alienFactories if the player has colonized the system.
+                // We could display alienFactories if the player has merely explored the system,
+                // just as we show the player the planet's current terraformed size.
+                for (int empId=0; empId<sys.galaxy().numEmpires(); empId++)
+                    if (sys.planet().alienFactories(empId) > 0) {
+                        str = sys.planet().alienFactories(empId).toString() + ' ' + sys.galaxy().empire(empId).name();
+                        g.setColor(sys.galaxy().empire(empId).nameColor());
+                        drawString(g, str, x0, y0);
+                        sw = g.getFontMetrics().stringWidth(str);
+                        x0 += sw + s4;
+                    }
         	}
         }
     }


### PR DESCRIPTION
Currently, captured factories are tracked by the game, but they are not shown to the player in any way. This shows the number of factories on the system panel. (Underneath incoming transports, if there are any incoming transports.) (I don't know if this is the best place for it, I just put it here since I was imitating the incoming-transports notice since that's what taught me how to put text on the system panel at all.)

This also fusses with the incoming-transports display code just a bit, removing a conditional that I think is redundant.

`playerPopApproachingSystem()` and `enemyPopApproachingPlayerSystem()` and `isPlayer()` are all called directly by `drawPlanetInfo()` anyway, so it doesn't seem like we need to call them via `showTransports()` first.

(Making it just a scoped block instead of a conditional allows the alienFactories display to piggyback off of it.)