### PR TITLE
Extract common code from ColonyEcology

### DIFF
--- a/src/rotp/model/colony/ColonyEcology.java
+++ b/src/rotp/model/colony/ColonyEcology.java
@@ -140,7 +140,7 @@ public class ColonyEcology extends ColonySpendingCategory {
 
         float prodBC = pct()* totalProd;
         float rsvBC = pct() * totalReserve;
-        float newBC = prodBC+rsvBC;
+        float newBC = totalAvailableBCthisCategory(totalProd, totalReserve);
 
         // add new waste created from this turn & clean it up
         addWaste(c.newWaste());
@@ -275,9 +275,7 @@ public class ColonyEcology extends ColonySpendingCategory {
         if (empire().ignoresPlanetEnvironment())
             return false;
         
-        float prodBC = pct()* colony().totalProductionIncome();
-        float rsvBC = pct() * colony().maxReserveIncome();
-        float newBC = prodBC+rsvBC; 
+        float newBC = totalAvailableBCthisCategory(colony().totalProductionIncome(), colony().maxReserveIncome());
         
         return (newBC < colony().wasteCleanupCost());
     }
@@ -285,9 +283,7 @@ public class ColonyEcology extends ColonySpendingCategory {
     public String upcomingResult(){
         Colony c = colony();
         
-        float prodBC = pct()* c.totalProductionIncome();
-        float rsvBC = pct() * c.maxReserveIncome();
-        float newBC = prodBC+rsvBC;
+        float newBC = totalAvailableBCthisCategory(colony().totalProductionIncome(), colony().maxReserveIncome());
         float cost;
 
         // new population
@@ -369,9 +365,7 @@ public class ColonyEcology extends ColonySpendingCategory {
         if (c.allocation(categoryType()) == 0)
             return 0;
         
-        float prodBC = pct()* c.totalProductionIncome();
-        float rsvBC = pct() * c.maxReserveIncome();
-        float totalBC = prodBC+rsvBC;        
+        float totalBC = totalAvailableBCthisCategory(colony().totalProductionIncome(), colony().maxReserveIncome());
         
         // deduct cost to clean industrial waste
         float cleanCost = c.wasteCleanupCost();

--- a/src/rotp/model/colony/ColonyEcology.java
+++ b/src/rotp/model/colony/ColonyEcology.java
@@ -129,6 +129,16 @@ public class ColonyEcology extends ColonySpendingCategory {
 
         return roomToGrow * tech().popIncreaseCost();
     }
+    public float wasteWillClean(float availableBC, float wasteToClean) {
+        Empire emp = colony().empire();
+        if (emp.ignoresPlanetEnvironment())
+            return 0;
+        else
+            return max(0, min((availableBC * emp.tech().wasteElimination()), wasteToClean));
+    }
+    public float wasteWillClean(float availableBC) {
+        return wasteWillClean(availableBC, waste());
+    }
     @Override
     public void nextTurn(float totalProd, float totalReserve) {
         Colony c = colony();
@@ -144,7 +154,7 @@ public class ColonyEcology extends ColonySpendingCategory {
 
         // add new waste created from this turn & clean it up
         addWaste(c.newWaste());
-        wasteCleaned = emp.ignoresPlanetEnvironment() ? 0 : max(0, min((newBC * tr.wasteElimination()), waste()));
+        wasteCleaned = wasteWillClean(newBC);
         newBC -= (wasteCleaned / tr.wasteElimination());
 
         // try to convert hostile atmosphere

--- a/src/rotp/model/colony/ColonySpendingCategory.java
+++ b/src/rotp/model/colony/ColonySpendingCategory.java
@@ -68,6 +68,11 @@ public abstract class ColonySpendingCategory implements Base, Serializable {
     public float totalBCForEmpire()     { return totalBC(); }
     public int allocation()             { return colony.allocation(categoryType()); }
     public float pct()                  { return (float)allocation()/ MAX_TICKS; }
+    public float totalAvailableBCthisCategory(float totalProd, float totalReserve) {
+        float prodBC = pct() * totalProd;
+        float rsvBC = pct() * totalReserve;
+        return prodBC + rsvBC;
+    }
     public boolean warning()            { return false; }
     public String overflowText()        { 
         if (!empire().divertColonyExcessToResearch())


### PR DESCRIPTION
I'm not sure if this is a good idea, but rather than chase down mismatches between the display and the actual production one at a time, I wonder if it would be better to --- very, very carefully --- extract the actual production code into functions that we can then call when drawing the display.

This does just a bit of that, extracting the first couple of operations.

This doesn't change any behavior as far as I know.