### PR TITLE
StarSystem knows whether it can show incoming transports

### DIFF
--- a/src/rotp/model/galaxy/StarSystem.java
+++ b/src/rotp/model/galaxy/StarSystem.java
@@ -323,8 +323,8 @@ public class StarSystem implements Base, Sprite, IMappedObject, Serializable {
         
     }
     public boolean canShowIncomingTransports() {
-        if (sys.planet().isColonized())
-            return sys.colony().showTransports();
+        if (planet().isColonized())
+            return colony().showTransports();
         return false;
     }
     public void resolvePendingTransports() {

--- a/src/rotp/model/galaxy/StarSystem.java
+++ b/src/rotp/model/galaxy/StarSystem.java
@@ -323,9 +323,9 @@ public class StarSystem implements Base, Sprite, IMappedObject, Serializable {
         
     }
     public boolean canShowIncomingTransports() {
-        boolean showTransports = false;
         if (sys.planet().isColonized())
             return sys.colony().showTransports();
+        return false;
     }
     public void resolvePendingTransports() {
         if (!hasOrbitingTransports())

--- a/src/rotp/model/galaxy/StarSystem.java
+++ b/src/rotp/model/galaxy/StarSystem.java
@@ -322,6 +322,11 @@ public class StarSystem implements Base, Sprite, IMappedObject, Serializable {
         }
         
     }
+    public boolean canShowIncomingTransports() {
+        boolean showTransports = false;
+        if (sys.planet().isColonized())
+            return sys.colony().showTransports();
+    }
     public void resolvePendingTransports() {
         if (!hasOrbitingTransports())
             return;

--- a/src/rotp/ui/main/SystemGraphicPane.java
+++ b/src/rotp/ui/main/SystemGraphicPane.java
@@ -91,8 +91,7 @@ public class SystemGraphicPane extends BasePanel implements MouseMotionListener,
         drawBorderedString(g0, str, 1, x0, y0, Color.black, SystemPanel.orangeText);
         
         // BR: Incoming transport
-        boolean showTransports = false;
-        if (sys.planet().isColonized()) { showTransports = sys.colony().showTransports(); }
+        boolean showTransports = sys.canShowIncomingTransports();
 
         //log("graphic h:", str(unscaled(h)));
         int x1 = showTransports? s10 : s5;

--- a/src/rotp/ui/main/SystemPanel.java
+++ b/src/rotp/ui/main/SystemPanel.java
@@ -249,7 +249,7 @@ public abstract class SystemPanel extends BasePanel implements SystemViewer, Map
     	boolean isPlayer = isPlayer(sys.empire());
         int y0 = s54;
         int x0 = s25;
-        if (showTransports) { // This test can't be removed! May leads to crash
+        if (sys.canShowIncomingTransports()) { // This test can't be removed! We cannot dereference colony() in an uncolonized system.
         	if (!isPlayer) {
             	int playerPop = sys.colony().playerPopApproachingSystem();;
                 g.setFont(narrowFont(20));

--- a/src/rotp/ui/map/SystemInfoPanel.java
+++ b/src/rotp/ui/map/SystemInfoPanel.java
@@ -163,10 +163,7 @@ public class SystemInfoPanel extends SystemPanel implements MouseMotionListener 
 
             if (!player().sv.isScouted(sys.id))
                 return;
-            boolean showTransports = false;
-            if (sys.planet().isColonized()) {
-            	showTransports = sys.colony().showTransports();
-            }
+            boolean showTransports = sys.canShowIncomingTransports();
             int x1 = showTransports? s10 : s5;
             int y1 = showTransports? s55 : s70/2;
             int r = showTransports? s70 : s80; //modnar: increase planet size

--- a/src/rotp/ui/planets/PlanetsUI.java
+++ b/src/rotp/ui/planets/PlanetsUI.java
@@ -1269,10 +1269,7 @@ public class PlanetsUI extends BasePanel implements SystemViewer {
             int x0 = s25;
             drawBorderedString(g, str, 2, x0, y0, Color.black, SystemPanel.orangeText);
 
-            boolean showTransports = false;
-            if (sys != null && sys.planet().isColonized()) {
-            	showTransports = sys.colony().showTransports();
-            }
+            boolean showTransports = sys != null && sys.canShowIncomingTransports();
             int x1 = showTransports? s10 : s5;
             int y1 = showTransports? s55 : s70/2;
             int r  = showTransports? s70 : s80; //modnar: increase planet size


### PR DESCRIPTION
Okay so, I screwed up before, but I still think we can avoid passing around a boolean. (Though this doesn't actually remove the parameter, just bypasses it.) This one definitely works with unexplored systems, explored uncolonized systems, player-colonized systems, and enemy-colonized systems.