### PR TITLE
Extract functions from ShipFleet and Transport to Ship

### DIFF
--- a/src/rotp/model/galaxy/Galaxy.java
+++ b/src/rotp/model/galaxy/Galaxy.java
@@ -46,7 +46,7 @@ import rotp.util.Base;
 public class Galaxy implements Base, Serializable {
     private static final long serialVersionUID = 1L;
     public static Galaxy current()   { return GameSession.instance().galaxy(); }
-    private static final float TIME_PER_TURN = 1;
+    public static final float TIME_PER_TURN = 1;
     public	static final String EMPIRES_KEY	= "SETUP_EMPIRE_LIST";
     public	static final String SYSTEMS_KEY	= "SETUP_SYSTEM_LIST";
 

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -16,12 +16,13 @@
 package rotp.model.galaxy;
 
 import java.util.Comparator;
+import rotp.model.Sprite;
 import rotp.model.empires.Empire;
 import rotp.ui.main.GalaxyMapPanel;
 import rotp.ui.sprites.FlightPathSprite;
 import rotp.util.Base;
 
-public interface Ship extends IMappedObject {
+public interface Ship extends IMappedObject, Sprite {
     static final int NOT_LAUNCHED = -1;
     default float hullPoints()          { return 0; }
     default boolean isRallied()         { return false; }

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -41,6 +41,7 @@ public interface Ship extends IMappedObject, Sprite {
     public float arrivalTime();
     public boolean visibleTo(int empId);
     public int empId();
+    default Empire empire() { return galaxy().empire(empId()); }
     public int destSysId();
     public boolean inTransit();
     public boolean deployed();

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -64,12 +64,14 @@ public interface Ship extends IMappedObject, Base, Sprite {
     default float transitY() {
         return fromY() + travelPct()*(destY() - fromY());
     }
-    default float travelPct() {
-        float currTime = galaxy().currentTime();
+    default float travelPct(float currTime) {
         if ((launchTime() == NOT_LAUNCHED) || (launchTime() == currTime))
             return 0;
         else 
             return (currTime-launchTime()) / (arrivalTime()-launchTime());
+    }
+    default float travelPct() {
+        return travelPct(galaxy().currentTime());
     }
 
     public boolean inTransit();

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -22,7 +22,7 @@ import rotp.ui.main.GalaxyMapPanel;
 import rotp.ui.sprites.FlightPathSprite;
 import rotp.util.Base;
 
-public interface Ship extends IMappedObject, Sprite {
+public interface Ship extends IMappedObject, Base, Sprite {
     static final int NOT_LAUNCHED = -1;
     default float hullPoints()          { return 0; }
     default boolean isRallied()         { return false; }
@@ -38,6 +38,7 @@ public interface Ship extends IMappedObject, Sprite {
     default boolean hasDisplayPanel() { return true; }
 
     public boolean canSendTo(int sysId);
+    public float launchTime();
     public float arrivalTime();
     public boolean visibleTo(int empId);
 
@@ -52,8 +53,31 @@ public interface Ship extends IMappedObject, Sprite {
     default Empire empire() { return galaxy().empire(empId()); }
     public int destSysId();
     default StarSystem destination() { return galaxy().system(destSysId());  }
+    default float destX() { return destination().x(); }
+    default float destY() { return destination().y(); }
+    // destination is always a star system, but origin point need not be?
+    public float fromX();
+    public float fromY();
+    default float transitX() {
+        return fromX() + travelPct()*(destX() - fromX());
+    }
+    default float transitY() {
+        return fromY() + travelPct()*(destY() - fromY());
+    }
+    default float travelPct() {
+        float currTime = galaxy().currentTime();
+        if ((launchTime() == NOT_LAUNCHED) || (launchTime() == currTime))
+            return 0;
+        else 
+            return (currTime-launchTime()) / (arrivalTime()-launchTime());
+    }
 
     public boolean inTransit();
+    @Override // from IMappedObject
+    default float x() { return inTransit() ? transitX() : fromX(); }
+    @Override // from IMappedObject
+    default float y() { return inTransit() ? transitY() : fromY(); }
+
     public boolean deployed();
     public FlightPathSprite pathSprite();
     public int maxMapScale();

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -73,6 +73,12 @@ public interface Ship extends IMappedObject, Base, Sprite {
     default float travelPct() {
         return travelPct(galaxy().currentTime());
     }
+    default float transitXlastTurn() {
+        return fromX() + travelPct(galaxy().currentTime() - Galaxy.TIME_PER_TURN)*(destX() - fromX());
+    }
+    default float transitYlastTurn() {
+        return fromY() + travelPct(galaxy().currentTime() - Galaxy.TIME_PER_TURN)*(destY() - fromY());
+    }
 
     public boolean inTransit();
     @Override // from IMappedObject

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -40,9 +40,19 @@ public interface Ship extends IMappedObject, Sprite {
     public boolean canSendTo(int sysId);
     public float arrivalTime();
     public boolean visibleTo(int empId);
+
+    // empId() and empire() provide the same information and either could be defined in terms of the other.
+    // ShipFleet directly stores the empId and defines empire() using the empId.
+    // Transport directly stores the empire and defines empId() using the empire.
+    // Either works fine. Which to provide a default implementation for is essentially arbitrary.
+    // We just can't provide a default implementation for *both* empId() and empire().
+    // Unfortunately, there is no Java construct for "any implementation must override at least one of these two functions."
+    // https://softwareengineering.stackexchange.com/questions/287234/is-it-good-practice-to-implement-two-java-8-default-methods-in-terms-of-each-oth
     public int empId();
     default Empire empire() { return galaxy().empire(empId()); }
     public int destSysId();
+    default StarSystem destination() { return galaxy().system(destSysId());  }
+
     public boolean inTransit();
     public boolean deployed();
     public FlightPathSprite pathSprite();

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -31,6 +31,11 @@ public interface Ship extends IMappedObject {
     default boolean retreating()        { return false; }
     default boolean isTransport()       { return false; }
 
+    @Override
+    default int displayPriority() { return 8; }
+    @Override
+    default boolean hasDisplayPanel() { return true; }
+
     public boolean canSendTo(int sysId);
     public float arrivalTime();
     public boolean visibleTo(int empId);

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -98,6 +98,7 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
     public void system(StarSystem s)    { sysId = id(s); }
     public StarSystem destination()     { return galaxy().system(destSysId);  }
     public float destY()                { return destY; }
+    public float fromY()                { return fromY; }
     public void makeOrbiting()          { status = Status.ORBITING; }
     public void makeDeployed()          { status = Status.DEPLOYED; }
     public void makeInTransit()         { status = Status.IN_TRANSIT; }
@@ -257,21 +258,6 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
     @Override
     public float y() { return isInTransit() ? transitY() : fromY; }
 
-    private float transitX() {
-        float p = travelPct();
-        return fromX + (p*(destX - fromX));
-    }
-    private float transitY() {
-        float p = travelPct();
-        return fromY + (p*(destY - fromY));
-    }
-    private float travelPct() {
-        float currTime = galaxy().currentTime();
-        if ((launchTime == NOT_LAUNCHED) || (launchTime == currTime))
-            return 0;
-        else 
-            return (currTime-launchTime) / (arrivalTime-launchTime);
-    }
     public void launch() {
         StarSystem sys = system();
         launch(sys.x(), sys.y());

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -98,6 +98,7 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
     public void system(StarSystem s)    { sysId = id(s); }
     public StarSystem destination()     { return galaxy().system(destSysId);  }
     public float destY()                { return destY; }
+    public float fromX()                { return fromX; }
     public float fromY()                { return fromY; }
     public void makeOrbiting()          { status = Status.ORBITING; }
     public void makeDeployed()          { status = Status.DEPLOYED; }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -90,16 +90,22 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
         else
             rallySysId = StarSystem.NULL_ID;
     }
+    @Override
     public Empire empire()              { return galaxy().empire(empId); }
     @Override
     public boolean retreating()         { return retreating; }
     public void retreating(boolean b)   { retreating = b; }
     public StarSystem system()          { return galaxy().system(sysId); }
     public void system(StarSystem s)    { sysId = id(s); }
+    @Override
     public StarSystem destination()     { return galaxy().system(destSysId);  }
+    @Override
     public float destY()                { return destY; }
+    @Override
     public float fromX()                { return fromX; }
+    @Override
     public float fromY()                { return fromY; }
+    @Override
     public float launchTime()           { return launchTime; }
     public void makeOrbiting()          { status = Status.ORBITING; }
     public void makeDeployed()          { status = Status.DEPLOYED; }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -100,6 +100,7 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
     public float destY()                { return destY; }
     public float fromX()                { return fromX; }
     public float fromY()                { return fromY; }
+    public float launchTime()           { return launchTime; }
     public void makeOrbiting()          { status = Status.ORBITING; }
     public void makeDeployed()          { status = Status.DEPLOYED; }
     public void makeInTransit()         { status = Status.IN_TRANSIT; }

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -112,7 +112,8 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public StarSystem destination()   { return dest; }
     public void setDest(StarSystem d) { dest = d; }
     public StarSystem from()          { return from; }
-    public StarSystem fromY()         { return from.y(); }
+    public float fromX()              { return from.x(); }
+    public float fromY()              { return from.y(); }
     public int size()                 { return size; }
     public void size(int s)           { size = s; }
     public int launchSize()           { return originalSize; }

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -112,7 +112,9 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public StarSystem destination()   { return dest; }
     public void setDest(StarSystem d) { dest = d; }
     public StarSystem from()          { return from; }
+    @Override
     public float fromX()              { return from.x(); }
+    @Override
     public float fromY()              { return from.y(); }
     public int size()                 { return size; }
     public void size(int s)           { size = s; }
@@ -121,6 +123,7 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public float hitPoints()          { return hitPoints; }
     public float combatTransportPct() { return combatTransportPct; }
     public float combatAdj()          { return combatAdj; }
+    @Override
     public float launchTime()         { return launchTime; }
     public Empire targetCiv()          { return targetEmp; }
     public void travelSpeed(float d)  { travelSpeed = d; }

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -112,6 +112,7 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public StarSystem destination()   { return dest; }
     public void setDest(StarSystem d) { dest = d; }
     public StarSystem from()          { return from; }
+    public StarSystem fromY()         { return from.y(); }
     public int size()                 { return size; }
     public void size(int s)           { size = s; }
     public int launchSize()           { return originalSize; }
@@ -146,17 +147,6 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public float x() { return inTransit() ? transitX() : from.x();  }
     @Override
     public float y() { return inTransit() ? transitY() : from.y();  }
-    private float transitX() {
-        float p = travelPct();
-        return from.x() + (p*(dest.x() - from.x()));
-    }
-    private float transitY() {
-        float p = travelPct();
-        return from.y() + (p*(dest.y() - from.y()));
-    }
-    private float travelPct() {
-        return (galaxy().currentTime()-launchTime) / (arrivalTime-launchTime);
-    }
     public boolean launched()       { return launchTime > NOT_LAUNCHED; }
     @Override
     public boolean deployed()       { return launched(); }


### PR DESCRIPTION
This doesn't change any behavior, but textually it makes changes to some hugely important classes, so it seemed wise to check in.

This extracts functions that are common to both ShipFleet and Transport into Ship.

(A ShipFleet is a Ship, not a collection of Ships. I don't make the rules.)

I didn't get into pondering why, for example, Transport has a star system it's `from()` but ShipFleet doesn't necessarily; I just extracted `fromX` and `fromY` which they both have.

This also adds `transitXlastTurn()` and `transitYlastTurn()` to Ship; these were all I really wanted in the first place. (I want to show the player where a ship was last turn if they don't have Improved Space Scanner but they did see this particular ship last turn.) Previously `travelPct` was available from both ShipFleet and Transport, but not from Ship.

(We could *store* the `Ship.x()` and `Ship.y()` when seen, of course, which would be more strictly correct in terms of firewalling off information that isn't available to the player, but more on-the-fly memory allocations would make it more expensive, versus just saving which ships were visible last turn and trusting those Ships to know where they were last turn. Anyway, this branch doesn't do any of that, it just extracts functions from ShipFleet and Transport to Ship so that they're callable when you only know you have a Ship.)