### PR TITLE
Don't send transports that will be shot down

### DIFF
--- a/src/rotp/model/ai/AI.java
+++ b/src/rotp/model/ai/AI.java
@@ -240,7 +240,7 @@ public class AI implements Base {
             ColonyTransporter col = createColony(sys, minTransportSize);
             if (col != null) {
                 if((col.popNeeded >= minTransportSize) && (col.popNeeded >= col.maxPopToGive)
-                   && (empire.estimatedFleetDamagePerRoundToArrivingTransports(col.starSystem().orbitingFleets()) < empire.tech().topArmorTech().transportHP))
+                   && (empire.estimatedFleetDamagePerRoundToArrivingTransports(sys.orbitingFleets()) < empire.tech().topArmorTech().transportHP))
                     needy.add(col);
                 else if ((col.maxPopToGive >= minTransportSize) && (col.maxPopToGive > col.popNeeded))
                 {

--- a/src/rotp/model/ai/AI.java
+++ b/src/rotp/model/ai/AI.java
@@ -239,7 +239,8 @@ public class AI implements Base {
         for (StarSystem sys: empire.allColonizedSystems()) {
             ColonyTransporter col = createColony(sys, minTransportSize);
             if (col != null) {
-                if ((col.popNeeded >= minTransportSize) && (col.popNeeded >= col.maxPopToGive))
+                if((col.popNeeded >= minTransportSize) && (col.popNeeded >= col.maxPopToGive)
+                   && (empire.estimatedFleetDamagePerRoundToArrivingTransports(col.starSystem().orbitingFleets()) < empire.tech().topArmorTech().transportHP))
                     needy.add(col);
                 else if ((col.maxPopToGive >= minTransportSize) && (col.maxPopToGive > col.popNeeded))
                 {

--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -1138,7 +1138,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
             return;
         }
         // Xilmi: when landing on our own planet we also can be shot down by orbiting enemies
-        float defenderDmg = fleetDamagePerRoundToArrivingTransports(tr.empId());
+        float defenderDmg = fleetDamagePerRoundToArrivingTransports(t.empId());
         int passed = 0;
         int lost = 0;
         int num = t.size();

--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -1117,6 +1117,18 @@ public final class Colony implements Base, IMappedObject, Serializable {
         // recalculate destination colony
         dest.colony().governIfNeeded();
     }
+    public float fleetDamagePerRoundToArrivingTransports(Transport t) {
+        float defenderDmg = 0;
+        List<ShipFleet> fleets = starSystem().orbitingFleets();
+        // add firepower for each allied ship in orbit
+            // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
+            // to prevent ground bombs from being able to damage transports
+        for (ShipFleet fl : fleets) {
+            if (fl.empire().aggressiveWith(t.empId()))
+                defenderDmg += fl.firepowerAntiShip(0);
+        }
+        return defenderDmg;
+    }
     public void acceptTransport(Transport t) {
         if (!t.empire().canColonize(starSystem())) {
             // no appropriate alert message for this transport loss. This is an edge case anyway
@@ -1126,12 +1138,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
             return;
         }
         // Xilmi: when landing on our own planet we also can be shot down by orbiting enemies
-        float defenderDmg = 0;
-        List<ShipFleet> fleets = starSystem().orbitingFleets();
-        for (ShipFleet fl : fleets) {
-            if (fl.empire().aggressiveWith(t.empId()))
-                defenderDmg += fl.firepowerAntiShip(0);
-        }
+        float defenderDmg = fleetDamagePerRoundToArrivingTransports();
         int passed = 0;
         int lost = 0;
         int num = t.size();
@@ -1162,12 +1169,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
                     str(tr.size()), " ", tr.empire().raceName(), " transports");
 
         // Xilmi: when landing on our own planet we also can be shot down by orbiting enemies
-        float defenderDmg = 0;
-        List<ShipFleet> fleets = starSystem().orbitingFleets();
-        for (ShipFleet fl : fleets) {
-            if (fl.empire().aggressiveWith(tr.empId()))
-                defenderDmg += fl.firepowerAntiShip(0);
-        }
+        float defenderDmg = fleetDamagePerRoundToArrivingTransports();
         int passed = 0;
         int lost = 0;
         int num = tr.size();
@@ -1273,11 +1275,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
         // add firepower for each allied ship in orbit
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
             // to prevent ground bombs from being able to damage transports
-        List<ShipFleet> fleets = starSystem().orbitingFleets();
-        for (ShipFleet fl : fleets) {
-            if (fl.empire().aggressiveWith(tr.empId()))
-                defenderDmg += fl.firepowerAntiShip(0);
-        }
+	defenderDmg += fleetDamagePerRoundToArrivingTransports();
 
         // run the gauntlet
         for (int j = 0; j < tr.gauntletRounds(); j++)

--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -1117,14 +1117,14 @@ public final class Colony implements Base, IMappedObject, Serializable {
         // recalculate destination colony
         dest.colony().governIfNeeded();
     }
-    public float fleetDamagePerRoundToArrivingTransports(Transport t) {
+    public float fleetDamagePerRoundToArrivingTransports(int empId) {
         float defenderDmg = 0;
         List<ShipFleet> fleets = starSystem().orbitingFleets();
         // add firepower for each allied ship in orbit
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
             // to prevent ground bombs from being able to damage transports
         for (ShipFleet fl : fleets) {
-            if (fl.empire().aggressiveWith(t.empId()))
+            if (fl.empire().aggressiveWith(empId))
                 defenderDmg += fl.firepowerAntiShip(0);
         }
         return defenderDmg;
@@ -1138,7 +1138,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
             return;
         }
         // Xilmi: when landing on our own planet we also can be shot down by orbiting enemies
-        float defenderDmg = fleetDamagePerRoundToArrivingTransports();
+        float defenderDmg = fleetDamagePerRoundToArrivingTransports(tr.empId());
         int passed = 0;
         int lost = 0;
         int num = t.size();
@@ -1169,7 +1169,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
                     str(tr.size()), " ", tr.empire().raceName(), " transports");
 
         // Xilmi: when landing on our own planet we also can be shot down by orbiting enemies
-        float defenderDmg = fleetDamagePerRoundToArrivingTransports();
+        float defenderDmg = fleetDamagePerRoundToArrivingTransports(tr.empId());
         int passed = 0;
         int lost = 0;
         int num = tr.size();
@@ -1275,7 +1275,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
         // add firepower for each allied ship in orbit
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
             // to prevent ground bombs from being able to damage transports
-	defenderDmg += fleetDamagePerRoundToArrivingTransports();
+	defenderDmg += fleetDamagePerRoundToArrivingTransports(tr.empId());
 
         // run the gauntlet
         for (int j = 0; j < tr.gauntletRounds(); j++)

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2323,9 +2323,9 @@ public final class Empire implements Base, NamedObject, Serializable {
             return 0;
         ShipView shipView = shipViewFor(design);
         if (shipView == null)
-            return estimatedShipFirepowerAntiShip(design.empire(), design.size(), shieldLevel);
+            return estimatedShipFirepower(design.empire(), design.size(), shieldLevel);
         else
-            return shipView.visibleFirepower(shieldLevel);
+            return shipView.visibleFirepowerAntiShip(shieldLevel);
     }
     public float estimatedFleetDamagePerRoundToArrivingTransports(List<ShipFleet> fleets) {
         float defenderDmg = 0;

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2309,7 +2309,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     public float estimatedShipFirepower(Empire emp, int shipSize, int shieldLevel) {
         return 0;
     }
-    public float estimatedShipFirepower(Empire emp, ShipDesign design, int shieldLevel) {
+    public float estimatedShipFirepower(ShipDesign design, int shieldLevel) {
         ShipView shipView = shipViewFor(design);
         if (shipView == null)
             return estimatedShipFirepower(design.empire(), design.size(), shieldLevel);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2310,6 +2310,7 @@ public final class Empire implements Base, NamedObject, Serializable {
         return 0;
     }
     public float estimatedShipFirepower(ShipDesign design, int shieldLevel) {
+        // We do not need to specifically handle the null case here, because shipViewFor() will just return null in that case.
         ShipView shipView = shipViewFor(design);
         if (shipView == null)
             return estimatedShipFirepower(design.empire(), design.size(), shieldLevel);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2318,6 +2318,15 @@ public final class Empire implements Base, NamedObject, Serializable {
         else
             return shipView.visibleFirepower(shieldLevel);
     }
+    public float estimatedShipFirepowerAntiShip(ShipDesign design, int shieldLevel) {
+        if (design == null)
+            return 0;
+        ShipView shipView = shipViewFor(design);
+        if (shipView == null)
+            return estimatedShipFirepowerAntiShip(design.empire(), design.size(), shieldLevel);
+        else
+            return shipView.visibleFirepower(shieldLevel);
+    }
     public float estimatedFleetDamagePerRoundToArrivingTransports(List<ShipFleet> fleets) {
         float defenderDmg = 0;
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2310,7 +2310,8 @@ public final class Empire implements Base, NamedObject, Serializable {
         return 0;
     }
     public float estimatedShipFirepower(ShipDesign design, int shieldLevel) {
-        // We do not need to specifically handle the null case here, because shipViewFor() will just return null in that case.
+        if (design == null)
+            return 0;
         ShipView shipView = shipViewFor(design);
         if (shipView == null)
             return estimatedShipFirepower(design.empire(), design.size(), shieldLevel);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2320,7 +2320,6 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public float estimatedFleetDamagePerRoundToArrivingTransports(List<ShipFleet> fleets) {
         float defenderDmg = 0;
-        List<ShipFleet> fleets = starSystem().orbitingFleets();
         // add firepower for each allied ship in orbit
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
             // to prevent ground bombs from being able to damage transports

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2320,7 +2320,6 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public float estimatedFleetDamagePerRoundToArrivingTransports(List<ShipFleet> fleets) {
         float defenderDmg = 0;
-        // add firepower for each allied ship in orbit
             // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
             // to prevent ground bombs from being able to damage transports
         for (ShipFleet fl : fleets) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2318,6 +2318,18 @@ public final class Empire implements Base, NamedObject, Serializable {
         else
             return shipView.visibleFirepower(shieldLevel);
     }
+    public float estimatedFleetDamagePerRoundToArrivingTransports(List<ShipFleet> fleets) {
+        float defenderDmg = 0;
+        List<ShipFleet> fleets = starSystem().orbitingFleets();
+        // add firepower for each allied ship in orbit
+            // modnar: use firepowerAntiShip to only count ship weapons that can hit ships
+            // to prevent ground bombs from being able to damage transports
+        for (ShipFleet fl : fleets) {
+            if (fl.empire().aggressiveWith(id))
+                defenderDmg += fl.visibleFirepowerAntiShip(id, 0);
+        }
+        return defenderDmg;
+    }
     public boolean canScoutTo(Location xyz) {
         Galaxy gal = galaxy();
         for (int i=0; i<gal.numStarSystems(); i++) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2309,6 +2309,13 @@ public final class Empire implements Base, NamedObject, Serializable {
     public float estimatedShipFirepower(Empire emp, int shipSize, int shieldLevel) {
         return 0;
     }
+    public float estimatedShipFirepower(Empire emp, ShipDesign design, int shieldLevel) {
+        ShipView shipView = shipViewFor(design);
+        if (shipView == null)
+            return estimatedShipFirepower(design.empire(), design.size(), shieldLevel);
+        else
+            return shipView.visibleFirepower(shieldLevel);
+    }
     public boolean canScoutTo(Location xyz) {
         Galaxy gal = galaxy();
         for (int i=0; i<gal.numStarSystems(); i++) {

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -170,6 +170,12 @@ public class ShipView implements Base,Serializable {
         else
             return owner.estimatedShipFirepower(empire, design.size(), shieldLevel);
     }
+    public float visibleFirepowerAntiShip(int shieldLevel) {
+        if (scanned)
+            return design.firepowerAntiShip(shieldLevel);
+        else
+            return owner.estimatedShipFirepower(empire, design.size(), shieldLevel);
+    }
     private void scanComputer() {
         computer = design.computer();
         attackLevel = (int) design.attackLevel()+empire.shipAttackBonus();

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -36,7 +36,9 @@ public class ShipView implements Base,Serializable {
     private final static int UNARMED = -1;
     private final static int UNKNOWN = 0;
     private final static int ARMED = 1;
+    // owner is the *viewing* empire.
     private final Empire owner;
+    // empire is the owner of the actual ship.
     private final Empire empire;
     private final ShipDesign design;
     private boolean detected = false;

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -412,6 +412,18 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
             return cnt * viewingEmpire.estimatedShipFirepower(design, shieldLevel);
         }).reduce(0f, (Float a, Float b) -> a + b); // this .reduce() is literally just .sum() for floats
     }
+    public float visibleFirepowerAntiShip(int viewingEmpireId, int shieldLevel) {
+        // visibleFirepowerAntiShip() is almost identical with visibleFirepower().
+        // It would be great if we could cut down the boilerplate even more, but some seems necessary for readability,
+        // like ShipDesign design = entry.getKey().
+        final Empire viewingEmpire = galaxy().empire(viewingEmpireId);
+        // cannot use mapToDouble().sum() nor Collectors.summingDouble https://rmannibucau.metawerx.net/java-stream-float-widening.html
+        return visibleShipDesigns(emp).entrySet().stream().map(entry -> {
+            ShipDesign design = entry.getKey();
+            int cnt = entry.getValue();
+            return cnt * viewingEmpire.estimatedShipFirepowerAntiShip(design, shieldLevel);
+        }).reduce(0f, (Float a, Float b) -> a + b); // this .reduce() is literally just .sum() for floats
+    }
     public boolean aggressiveWith(ShipFleet fl, StarSystem sys) {
         // only possibly aggressive if one of the fleets is armed
         if (isArmed() || fl.isArmed())

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -418,7 +418,7 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
         // like ShipDesign design = entry.getKey().
         final Empire viewingEmpire = galaxy().empire(viewingEmpireId);
         // cannot use mapToDouble().sum() nor Collectors.summingDouble https://rmannibucau.metawerx.net/java-stream-float-widening.html
-        return visibleShipDesigns(emp).entrySet().stream().map(entry -> {
+        return visibleShipDesigns(viewingEmpireId).entrySet().stream().map(entry -> {
             ShipDesign design = entry.getKey();
             int cnt = entry.getValue();
             return cnt * viewingEmpire.estimatedShipFirepowerAntiShip(design, shieldLevel);

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -404,16 +404,13 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
         // it only checks visible stacks for sv's owner
         // for unscanned ShipDesigns it asks the sv's owner to estimate threat based on size
         //  (this allows the owner to check any spied tech trees for worst possible weapons)
-
-        float firepower = 0;
-        int[] visible = visibleShips(emp);
-        for (Map.Entry<ShipDesign, Integer> entry : visibleShipDesigns(emp).entrySet()) {
+        final Empire viewingEmpire = galaxy().empire(emp);
+        // cannot use mapToDouble().sum() nor Collectors.summingDouble https://rmannibucau.metawerx.net/java-stream-float-widening.html
+        return visibleShipDesigns(emp).entrySet().stream().map(entry -> {
             ShipDesign design = entry.getKey();
             int cnt = entry.getValue();
-            if (design != null)
-                firepower += cnt * galaxy().empire(emp).estimatedShipFirepower(design, shieldLevel);
-        }
-        return firepower;
+            return cnt * viewingEmpire.estimatedShipFirepower(design, shieldLevel);
+        }).reduce(0f, (Float a, Float b) -> a + b); // this .reduce() is literally just .sum() for floats
     }
     public boolean aggressiveWith(ShipFleet fl, StarSystem sys) {
         // only possibly aggressive if one of the fleets is armed

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -410,14 +410,8 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
         for (Map.Entry<ShipDesign, Integer> entry : visibleShipDesigns(emp).entrySet()) {
             ShipDesign design = entry.getKey();
             int cnt = entry.getValue();
-            if (design != null) {
-                Empire empire = galaxy().empire(emp);
-                ShipView shipView = empire.shipViewFor(design);
-                if (shipView == null)
-                    firepower += (cnt * empire.estimatedShipFirepower(empire(), design.size(), shieldLevel));
-                else
-                    firepower += (cnt * shipView.visibleFirepower(shieldLevel));
-            }
+            if (design != null)
+                firepower += cnt * galaxy().empire(emp).estimatedShipFirepower(design, shieldLevel);
         }
         return firepower;
     }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -392,11 +392,12 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
             if (cnt > 0) {
                 ShipDesign design = design(i);
                 if (design == null)
-                    ret.put(null, ret.getOrDefault(null, 0) + cnt)
+                    ret.put(null, ret.getOrDefault(null, 0) + cnt);
                 else
-                    ret.put(design, cnt)
+                    ret.put(design, cnt);
             }
         }
+        return ret;
     }
     public float visibleFirepower(int emp, int shieldLevel) {
         // this calculates the visible firepower threat against SystemView sv
@@ -406,7 +407,9 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
 
         float firepower = 0;
         int[] visible = visibleShips(emp);
-        visibleShipDesigns().forEach((design, cnt) -> {
+        for (Map.Entry<ShipDesign, Integer> entry : visibleShipDesigns(emp).entrySet()) {
+            ShipDesign design = entry.getKey();
+            int cnt = entry.getValue();
             if (design != null) {
                 Empire empire = galaxy().empire(emp);
                 ShipView shipView = empire.shipViewFor(design);
@@ -415,7 +418,7 @@ public class ShipFleet implements Base, Sprite, Ship, Serializable {
                 else
                     firepower += (cnt * shipView.visibleFirepower(shieldLevel));
             }
-        });
+        }
         return firepower;
     }
     public boolean aggressiveWith(ShipFleet fl, StarSystem sys) {


### PR DESCRIPTION
The only behavioral change this makes is that autotransport will not send transports when there is currently an enemy fleet orbiting the destination that will shoot the transports down.

If there is an unarmed scout parked over the planet, autotransport will still send transports normally. (...I just now realize that I'm not really sure why the AI likes to park unarmed scouts over enemy planets, but anyway, autotransport will ignore them.)

This introduces a bunch of machinery that it doesn't really take advantage of, because it's not doing anything very smart: it ignores the transports' travel time to the destination and ignores any enemy fleets that might be visibly en route. That kind of logic gets complicated *fast*, because you might, for example, build warships before the enemy fleets arrive. So I haven't made it do anything like that, but the "firewalled" `estimatedFleetDamagePerRoundToArrivingTransports()` using only information available to the empire means we *could* do something like that.

For ships already in orbit, you get a free scan anyway, but for ships en route, we have to be very careful about what information is available to the empire at the time. `estimatedFleetDamagePerRoundToArrivingTransports()` does that.

It seems reasonably safe to assume that if there is currently a blockade, transports should not be sent, especially since (within a given single year) friendly transports are assumed to arrive (and get shot down) before friendly relief fleets. (Though even for this, for long transport-trips there can be exceptions.)

This also deduplicates the firepower sum for arriving transports within Colony, but it *doesn't* deduplicate between the firepower sum over real ships (the *real* sum, in Colony) and the firepower sum over ShipViews (used only for making decisions). It would be nice to have those using common utility functions since the same conditionals should always apply to both (e.g. when modnar made only anti-ship firepower apply to transports, any change like that should apply equally to both), but I haven't figured out how to make that happen. As you can see, there's still a *lot* of duplicated code in this.