### PR TITLE
Check whether can track ships from turn to turn

### DIFF
--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2321,6 +2321,9 @@ public final class Empire implements Base, NamedObject, Serializable {
         return false;
     }
     public boolean knowsCouldNotHaveBeenSameTransportLastTurn(Transport transportNow, Transport transportLastTurn) {
+        // There is no concept of a ShipView for transports, but size is always visible.
+        if transportNow.size() != transportLastTurn.size()
+            return true;
         return false;
     }
     public boolean knowsShipNotBuiltThisTurn(Ship ufo) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2278,12 +2278,16 @@ public final class Empire implements Base, NamedObject, Serializable {
     public Map<Ship, Ship> matchShipsSeenThisTurnToShipsSeenLastTurn(List<Ship> visibleShips, Set<Ship> shipsVisibleLastTurnDestroyed) {
         Map<Ship, Ship> ret = new HashMap<Ship, Ship>();
         for (Ship ufo : visibleShips) {
-            if (!knowsNotBuiltThisTurn(ufo))
+            if (!knowsShipNotBuiltThisTurn(ufo))
                 continue;
 	}
         return ret;
     }
-    public boolean knowsNotBuiltThisTurn(Ship ufo) {
+    public boolean knowsShipNotBuiltThisTurn(Ship ufo) {
+        // If the ship does not have the same coordinates as any star --- that is,
+        // if it's in deep space, not deploying from a star system,
+        // then it could not have been built this turn.
+        // Ship already stores that information, so we can just reference it.
         return ufo.inTransit();
     }
     public boolean canScanTo(IMappedObject loc) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2304,7 +2304,7 @@ public final class Empire implements Base, NamedObject, Serializable {
                     .min(Comparator.<Float>naturalOrder()).get();
     }
     public float maxSpeedTransportMightHave(Transport transport) {
-        empireView = viewForEmpire(transport.empire());
+        EmpireView empireView = viewForEmpire(transport.empire());
         if (empireView == null)
             return 8;
         SpyNetwork spies = empireView.spies();

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2304,7 +2304,12 @@ public final class Empire implements Base, NamedObject, Serializable {
                     .min(Comparator.<Float>naturalOrder()).get();
     }
     public float maxSpeedTransportMightHave(Transport transport) {
-        return 8;
+        empireView = viewForEmpire(transport.empire());
+        if (empireView == null)
+            return 8;
+        SpyNetwork spies = empireView.spies();
+        // No matter how fast you research, it is impossible to discover more than one propulsion tech per turn.
+        return Math.min(8, spies.tech().transportTravelSpeed() + spies.reportAge());
     }
     public boolean canScanTo(IMappedObject loc) {
         return planetsCanScanTo(loc) || shipsCanScanTo(loc);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2291,14 +2291,14 @@ public final class Empire implements Base, NamedObject, Serializable {
             // it must have been seen last turn. The question then becomes uniquely identifying it.
             boolean foundMatch = false;
             for (Ship ufoLastTurn : shipsVisibleLastTurnDestroyed)
-                if (!knowsTheseTwoShipsDifferent(ufo, ufoLastTurn))
+                if (!knowsCouldNotHaveBeenSameShipLastTurn(ufo, ufoLastTurn))
                     if (foundMatch) {
                         foundMatch = false;
                         ret.remove(ufo);
                         break;
                     }
                     else {
-                        alreadyFoundMatch = true;
+                        foundMatch = true;
                         ret.put(ufo, ufoLastTurn);
                     }
             if (foundMatch)

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2362,7 +2362,7 @@ public final class Empire implements Base, NamedObject, Serializable {
         if (planetScanningRange() == 0)
             return false;
 
-        // could we use distanceTo() here?
+        // could we use this.distanceTo() here?
         Galaxy gal = galaxy();
         for (int i=0; i<sv.count(); i++) {
             if ((sv.empire(i) == this) && (gal.system(i).distanceTo(loc) <= planetScanningRange()))
@@ -2466,6 +2466,8 @@ public final class Empire implements Base, NamedObject, Serializable {
         }
         return distance;
     }
+    // If calculating square roots is a big enough problem that we have to cache them and have a special "Recalculating system distances"
+    // popup when recalculating them, should we just...not take any square roots, and compare squared distances?
     public int rangeTo(StarSystem sys) {
         return (int) Math.ceil(sv.distance(sys.id));
     }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2326,6 +2326,11 @@ public final class Empire implements Base, NamedObject, Serializable {
             return true;
         return false;
     }
+    public Map<ShipView, Integer> visibleShipViews(ShipFleet fleet) {
+        Map<ShipDesign, Integer> designs = fleet.visibleShipDesigns(id);
+        // designs.map(entry -> );
+        return null;
+    }
     public boolean knowsShipNotBuiltThisTurn(Ship ufo) {
         // If the ship does not have the same coordinates as any star --- that is,
         // if it's in deep space, not deploying from a star system,

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2318,7 +2318,7 @@ public final class Empire implements Base, NamedObject, Serializable {
         // No matter how fast you research, it is impossible to discover more than one propulsion tech per turn.
         return Math.min(8, spies.tech().transportTravelSpeed() + spies.reportAge());
     }
-    public knowsShipCouldNotHaveFlownInFromOutsideScanRange(Ship ufo) {
+    public boolean knowsShipCouldNotHaveFlownInFromOutsideScanRange(Ship ufo) {
         // For simplicity, we completely ignore scan coverage from ships.
         return distanceTo(ufo) + maxSpeedShipMightHave(ufo) < planetScanningRange();
     }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2327,9 +2327,18 @@ public final class Empire implements Base, NamedObject, Serializable {
         return false;
     }
     public Map<ShipView, Integer> visibleShipViews(ShipFleet fleet) {
+        // shipViewFor(design) might be null because design is null, or it might be null when there is a design but we have no ShipView for that design.
         Map<ShipDesign, Integer> designs = fleet.visibleShipDesigns(id);
-        // designs.map(entry -> );
-        return null;
+        int numberOfShipsWithMissingDesign = 0;
+        if (designs.containsKey(null))
+            numberOfShipsWithMissingDesign = designs.get(null);
+        Map<ShipView, Integer> ret = designs.entrySet().stream().filter(Objects::nonNull).collect(Collectors.toMap(
+            entry -> shipViewFor(entry.getKey()),
+            Map.Entry::getValue
+        ));
+        if (numberOfShipsWithMissingDesign > 0)
+            ret.put(null, ret.get(null) + numberOfShipsWithMissingDesign);
+        return ret;
     }
     public boolean knowsShipNotBuiltThisTurn(Ship ufo) {
         // If the ship does not have the same coordinates as any star --- that is,

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2292,9 +2292,9 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public float maxSpeedShipMightHave(Ship ufo) {
         if (ufo instanceof ShipFleet)
-            return maxSpeedFleetMightHave(ufo);
+            return maxSpeedFleetMightHave((ShipFleet)ufo);
         if (ufo instanceof Transport)
-            return maxSpeedTransportMightHave(ufo);
+            return maxSpeedTransportMightHave((Transport)ufo);
         return 9;
     }
     public float maxSpeedFleetMightHave(ShipFleet fleet) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -123,9 +123,6 @@ public final class Empire implements Base, NamedObject, Serializable {
     public final SystemInfo sv;
     private final EmpireView[] empireViews;
     private final List<Ship> visibleShips = new ArrayList<>();
-    // To strictly firewall off privileged information, the right thing to do would be to store the coordinates of ships seen last turn.
-    // The *identity* of the ship, as represented by the Ship object, is not necessarily known to the empire.
-    // But it's cheaper to just store the ships that were seen and ask them after-the-fact where they were last turn.
     private final List<StarSystem> shipBuildingSystems = new ArrayList<>();
     private final List<StarSystem> colonizedSystems = new ArrayList<>();
     private boolean extinct = false;
@@ -2249,6 +2246,9 @@ public final class Empire implements Base, NamedObject, Serializable {
     public void setVisibleShips() {
         Galaxy gal = galaxy();
         // This takes advantage of the fact that setVisibleShips() is called exactly once per turn.
+        // To strictly firewall off privileged information, the right thing to do would be to store the coordinates of ships seen last turn.
+        // The *identity* of the ship, as represented by the Ship object, is not necessarily known to the empire.
+        // But it's cheaper to just store the ships that were seen and ask them after-the-fact where they were last turn.
         final Set<Ship> shipsVisibleLastTurn = new HashSet<>(visibleShips);
         visibleShips.clear();
 
@@ -2275,8 +2275,16 @@ public final class Empire implements Base, NamedObject, Serializable {
                 detectFleet((ShipFleet)fl);
         }
     }
-    public Map<Ship, Ship> matchShipsSeenThisTurnToShipsSeenLastTurn(List<Ship> visibleShips, Set<Ship> shipsVisibleLastTurn) {
-        return null;
+    public Map<Ship, Ship> matchShipsSeenThisTurnToShipsSeenLastTurn(List<Ship> visibleShips, Set<Ship> shipsVisibleLastTurnDestroyed) {
+        Map<Ship, Ship> ret = new HashMap<Ship, Ship>();
+        for (Ship ufo : visibleShips) {
+            if (!knowsNotBuiltThisTurn(ufo))
+                continue;
+	}
+        return ret;
+    }
+    public knowsNotBuiltThisTurn(Ship ufo) {
+        return ufo.inTransit();
     }
     public boolean canScanTo(IMappedObject loc) {
         return planetsCanScanTo(loc) || shipsCanScanTo(loc);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -126,7 +126,6 @@ public final class Empire implements Base, NamedObject, Serializable {
     // To strictly firewall off privileged information, the right thing to do would be to store the coordinates of ships seen last turn.
     // The *identity* of the ship, as represented by the Ship object, is not necessarily known to the empire.
     // But it's cheaper to just store the ships that were seen and ask them after-the-fact where they were last turn.
-    private final Set<Ship> shipsVisibleLastTurn = new HashSet<>();
     private final List<StarSystem> shipBuildingSystems = new ArrayList<>();
     private final List<StarSystem> colonizedSystems = new ArrayList<>();
     private boolean extinct = false;
@@ -265,7 +264,6 @@ public final class Empire implements Base, NamedObject, Serializable {
             return galaxy().ships.notInTransitFleets(id);
     }
     public List<Ship> visibleShips()              { return visibleShips; }
-    public Set<Ship> shipsVisibleLastTurn()      { return shipsVisibleLastTurn; }
     public EmpireView[] empireViews()             { return empireViews; }
     public List<StarSystem> newSystems()          { return newSystems; }
     public int lastCouncilVoteEmpId()             { return lastCouncilVoteEmpId; }
@@ -2251,8 +2249,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     public void setVisibleShips() {
         Galaxy gal = galaxy();
         // This takes advantage of the fact that setVisibleShips() is called exactly once per turn.
-        shipsVisibleLastTurn.clear();
-        shipsVisibleLastTurn.addAll(visibleShips);
+        final Set<Ship> shipsVisibleLastTurn = new HashSet<>(visibleShips);
         visibleShips.clear();
 
         List<ShipFleet> myShips = galaxy().ships.allFleets(id);
@@ -2277,6 +2274,9 @@ public final class Empire implements Base, NamedObject, Serializable {
             if (fl instanceof ShipFleet)
                 detectFleet((ShipFleet)fl);
         }
+    }
+    public Map<Ship, Ship> matchShipsSeenThisTurnToShipsSeenLastTurn(List<Ship> visibleShips, Set<Ship> shipsVisibleLastTurn) {
+        return null;
     }
     public boolean canScanTo(IMappedObject loc) {
         return planetsCanScanTo(loc) || shipsCanScanTo(loc);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2290,6 +2290,22 @@ public final class Empire implements Base, NamedObject, Serializable {
         // Ship already stores that information, so we can just reference it.
         return ufo.inTransit();
     }
+    public float maxSpeedShipMightHave(Ship ufo) {
+        if (ufo instanceof ShipFleet)
+            return maxSpeedFleetMightHave(ufo);
+        if (ufo instanceof Transport)
+            return maxSpeedTransportMightHave(ufo);
+        return 9;
+    }
+    public float maxSpeedFleetMightHave(ShipFleet fleet) {
+        return fleet.visibleShipDesigns(id).keySet().stream()
+                    .map(design -> shipViewFor(design))
+                    .map(view -> (view == null) ? 9 : view.maxPossibleWarpSpeed())
+                    .min(Comparator.<Float>naturalOrder()).get();
+    }
+    public float maxSpeedTransportMightHave(Transport transport) {
+        return 8;
+    }
     public boolean canScanTo(IMappedObject loc) {
         return planetsCanScanTo(loc) || shipsCanScanTo(loc);
     }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2319,6 +2319,12 @@ public final class Empire implements Base, NamedObject, Serializable {
         return false;
     }
     public boolean knowsCouldNotHaveBeenSameFleetLastTurn(ShipFleet fleetNow, ShipFleet fleetLastTurn) {
+        if (!visibleShipViews(fleetNow).equals(visibleShipViews(fleetLastTurn)))
+            // This defers to ShipView.equals() for the ships that have ShipViews,
+            // and compares the count of each as well as the count of all ships that lack ShipViews.
+            // Strictly speaking, we could implement ShipView.equals(), but letting ShipView inherit .equals from Object works,
+            // because two ShipViews are always distinguishable.
+            return true;
         return false;
     }
     public boolean knowsCouldNotHaveBeenSameTransportLastTurn(Transport transportNow, Transport transportLastTurn) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2373,7 +2373,13 @@ public final class Empire implements Base, NamedObject, Serializable {
             return 8;
         SpyNetwork spies = empireView.spies();
         // No matter how fast you research, it is impossible to discover more than one propulsion tech per turn.
-        return Math.min(8, spies.tech().transportTravelSpeed() + spies.reportAge());
+        // But nevertheless someone could have researched Hyper Drives without even having researched Nuclear Engines first.
+        // propulsion().maxKnownQuintile() cannot increase more than one per turn.
+        // But nevertheless there might be an unencountered empire which researched Hyper Drives and traded it to the encountered empire.
+        // So the only way to be *sure* is if the report is current.
+        if (spies.reportAge() == 0)
+            return spies.tech().transportTravelSpeed();
+        return 8;
     }
     public boolean knowsShipCouldNotHaveFlownInFromOutsideScanRange(Ship ufo) {
         // For simplicity, we completely ignore scan coverage from ships.

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2322,7 +2322,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public boolean knowsCouldNotHaveBeenSameTransportLastTurn(Transport transportNow, Transport transportLastTurn) {
         // There is no concept of a ShipView for transports, but size is always visible.
-        if transportNow.size() != transportLastTurn.size()
+        if (transportNow.size() != transportLastTurn.size())
             return true;
         return false;
     }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -123,6 +123,9 @@ public final class Empire implements Base, NamedObject, Serializable {
     public final SystemInfo sv;
     private final EmpireView[] empireViews;
     private final List<Ship> visibleShips = new ArrayList<>();
+    // To strictly firewall off privileged information, the right thing to do would be to store the coordinates of ships seen last turn.
+    // The *identity* of the ship, as represented by the Ship object, is not necessarily known to the empire.
+    // But it's cheaper to just store the ships that were seen and ask them after-the-fact where they were last turn.
     private final Set<Ship> shipsVisibleLastTurn = new HashSet<>();
     private final List<StarSystem> shipBuildingSystems = new ArrayList<>();
     private final List<StarSystem> colonizedSystems = new ArrayList<>();

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2311,6 +2311,16 @@ public final class Empire implements Base, NamedObject, Serializable {
             return true;
         if (ufoNow.isTransport() != ufoLastTurn.isTransport())
             return true;
+        if (ufoNow instanceof ShipFleet && ufoLastTurn instanceof ShipFleet)
+            return knowsCouldNotHaveBeenSameFleetLastTurn((ShipFleet)ufoNow, (ShipFleet)ufoLastTurn);
+        if (ufoNow instanceof Transport && ufoLastTurn instanceof Transport)
+            return knowsCouldNotHaveBeenSameTransportLastTurn((Transport)ufoNow, (Transport)ufoLastTurn);
+        return false;
+    }
+    public boolean knowsCouldNotHaveBeenSameFleetLastTurn(ShipFleet fleetNow, ShipFleet fleetLastTurn) {
+        return false;
+    }
+    public boolean knowsCouldNotHaveBeenSameTransportLastTurn(Transport transportNow, Transport transportLastTurn) {
         return false;
     }
     public boolean knowsShipNotBuiltThisTurn(Ship ufo) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2329,6 +2329,7 @@ public final class Empire implements Base, NamedObject, Serializable {
         if (planetScanningRange() == 0)
             return false;
 
+        // could we use distanceTo() here?
         Galaxy gal = galaxy();
         for (int i=0; i<sv.count(); i++) {
             if ((sv.empire(i) == this) && (gal.system(i).distanceTo(loc) <= planetScanningRange()))
@@ -2412,6 +2413,7 @@ public final class Empire implements Base, NamedObject, Serializable {
         Galaxy gal = galaxy();
         List<Empire> allies = this.allies();
         if (allies.isEmpty()) {
+            // could we use allColonizedSystems() here?
             for (int i=0; i<gal.numStarSystems(); i++) {
                 StarSystem s = gal.system(i);
                 if (s.empire() == this)

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2283,7 +2283,7 @@ public final class Empire implements Base, NamedObject, Serializable {
 	}
         return ret;
     }
-    public knowsNotBuiltThisTurn(Ship ufo) {
+    public boolean knowsNotBuiltThisTurn(Ship ufo) {
         return ufo.inTransit();
     }
     public boolean canScanTo(IMappedObject loc) {

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -123,6 +123,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     public final SystemInfo sv;
     private final EmpireView[] empireViews;
     private final List<Ship> visibleShips = new ArrayList<>();
+    private final List<Ship> shipsVisibleLastTurn = new ArrayList<>();
     private final List<StarSystem> shipBuildingSystems = new ArrayList<>();
     private final List<StarSystem> colonizedSystems = new ArrayList<>();
     private boolean extinct = false;
@@ -261,6 +262,7 @@ public final class Empire implements Base, NamedObject, Serializable {
             return galaxy().ships.notInTransitFleets(id);
     }
     public List<Ship> visibleShips()              { return visibleShips; }
+    public List<Ship> shipsVisibleLastTurn()      { return shipsVisibleLastTurn; }
     public EmpireView[] empireViews()             { return empireViews; }
     public List<StarSystem> newSystems()          { return newSystems; }
     public int lastCouncilVoteEmpId()             { return lastCouncilVoteEmpId; }
@@ -2245,6 +2247,9 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public void setVisibleShips() {
         Galaxy gal = galaxy();
+        // This takes advantage of the fact that setVisibleShips() is called exactly once per turn.
+        shipsVisibleLastTurn.clear();
+        shipsVisibleLastTurn.addAll(visibleShips);
         visibleShips.clear();
 
         List<ShipFleet> myShips = galaxy().ships.allFleets(id);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2276,10 +2276,17 @@ public final class Empire implements Base, NamedObject, Serializable {
         }
     }
     public Map<Ship, Ship> matchShipsSeenThisTurnToShipsSeenLastTurn(List<Ship> visibleShips, Set<Ship> shipsVisibleLastTurnDestroyed) {
+        // This function attempts to match ships seen last turn with ships seen this turn (to determine trajectories).
+        // Obviously, we have the object references in hand, so we could just compare their identities.
+        // But the point is to find out whether *the empire* can do that using only the information available.
         Map<Ship, Ship> ret = new HashMap<Ship, Ship>();
         for (Ship ufo : visibleShips) {
             if (!knowsShipNotBuiltThisTurn(ufo))
                 continue;
+            if (!knowsShipCouldNotHaveFlownInFromOutsideScanRange(ufo))
+                continue;
+            // If it definitely wasn't built this turn, and it definitely wasn't outside scan range last turn, then
+            // it must have been seen last turn. The question then becomes uniquely identifying it.
 	}
         return ret;
     }
@@ -2310,6 +2317,10 @@ public final class Empire implements Base, NamedObject, Serializable {
         SpyNetwork spies = empireView.spies();
         // No matter how fast you research, it is impossible to discover more than one propulsion tech per turn.
         return Math.min(8, spies.tech().transportTravelSpeed() + spies.reportAge());
+    }
+    public knowsShipCouldNotHaveFlownInFromOutsideScanRange(Ship ufo) {
+        // For simplicity, we completely ignore scan coverage from ships.
+        return distanceTo(ufo) + maxSpeedShipMightHave(ufo) < planetScanningRange();
     }
     public boolean canScanTo(IMappedObject loc) {
         return planetsCanScanTo(loc) || shipsCanScanTo(loc);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -123,7 +123,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     public final SystemInfo sv;
     private final EmpireView[] empireViews;
     private final List<Ship> visibleShips = new ArrayList<>();
-    private final List<Ship> shipsVisibleLastTurn = new ArrayList<>();
+    private final Set<Ship> shipsVisibleLastTurn = new HashSet<>();
     private final List<StarSystem> shipBuildingSystems = new ArrayList<>();
     private final List<StarSystem> colonizedSystems = new ArrayList<>();
     private boolean extinct = false;
@@ -262,7 +262,7 @@ public final class Empire implements Base, NamedObject, Serializable {
             return galaxy().ships.notInTransitFleets(id);
     }
     public List<Ship> visibleShips()              { return visibleShips; }
-    public List<Ship> shipsVisibleLastTurn()      { return shipsVisibleLastTurn; }
+    public Set<Ship> shipsVisibleLastTurn()      { return shipsVisibleLastTurn; }
     public EmpireView[] empireViews()             { return empireViews; }
     public List<StarSystem> newSystems()          { return newSystems; }
     public int lastCouncilVoteEmpId()             { return lastCouncilVoteEmpId; }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -89,6 +89,12 @@ public class ShipView implements Base,Serializable {
     // The warp speed is always known and displayed.
     // (I guess this follows from canDistinguishFromOtherDesigns(), as scanners track a ship over the course of a year?)
     public static boolean warpSpeedKnown() { return true; }
+    public float maxPossibleWarpSpeed() {
+        if (warpSpeedKnown())
+            return design.warpSpeed();
+        else
+            return 9;
+    }
 
     public boolean hasComputer()        { return computer != null; }
     public boolean computerKnown()      { return computerKnown; }

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -264,7 +264,7 @@ public class ShipView implements Base,Serializable {
     }
     // For the reporting name given by the viewing empire, we use the actual name of the design.
     // (The player will never have access to the "real" name, so there's no need for the reporting name to be different.)
-    public int reportingName()       { return design.name(); }
+    public String reportingName()    { return design.name(); }
     public int hits()                { return hits; }
     public ShipShield shield()       { return shield; }
     public ShipComputer computer()   { return computer; }

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -78,6 +78,18 @@ public class ShipView implements Base,Serializable {
     public int totalKilled()              { return totalKilled; }
     public void addTotalKilled(int i)     { totalKilled += i; }
 
+    // A ShipView is always tied to exactly one ShipDesign.
+    // In the case of un-encountered empires, when only ship size is known, no ShipView is created.
+    // A public static function that always returns true is obviously completely vacuous,
+    // but serves as a hook where we could potentially have other kinds of views for un-encountered empires.
+    // (And links IDEs to where the fact that the design is distinguishable is *used* in the RacesMilitaryUI.)
+    public static boolean canDistinguishFromOtherDesigns() { return true; }
+    // The size is always known and displayed.
+    public static boolean sizeKnown() { return true; }
+    // The warp speed is always known and displayed.
+    // (I guess this follows from canDistinguishFromOtherDesigns(), as scanners track a ship over the course of a year?)
+    public static boolean warpSpeedKnown() { return true; }
+
     public boolean hasComputer()        { return computer != null; }
     public boolean computerKnown()      { return computerKnown; }
     public boolean hasShield()          { return shield != null; }
@@ -100,7 +112,7 @@ public class ShipView implements Base,Serializable {
     public boolean beamDefenseKnown()   { return beamDefenseKnown; }
     public boolean attackLevelKnown()   { return attackLevelKnown; }
     public boolean combatSpeedKnown()   { return combatSpeedKnown; }
-    
+
     public boolean isPotentiallyArmed() { return armedFlag != UNARMED; }
 
     public void setViewDate() {
@@ -250,6 +262,9 @@ public class ShipView implements Base,Serializable {
         }
         return spec;
     }
+    // For the reporting name given by the viewing empire, we use the actual name of the design.
+    // (The player will never have access to the "real" name, so there's no need for the reporting name to be different.)
+    public int reportingName()       { return design.name(); }
     public int hits()                { return hits; }
     public ShipShield shield()       { return shield; }
     public ShipComputer computer()   { return computer; }

--- a/src/rotp/model/galaxy/IMappedObject.java
+++ b/src/rotp/model/galaxy/IMappedObject.java
@@ -28,6 +28,14 @@ public interface IMappedObject {
     default public float distanceTo (IMappedObject obj) {
         return distanceTo(obj.x(), obj.y());
     }
+    default float squaredDistanceTo (float x2, float y2) {
+        float horizontalDistance = x() - x2;
+        float verticalDistance = y() - y2;
+        return horizontalDistance*horizontalDistance + verticalDistance*verticalDistance;
+    }
+    default float squaredDistanceTo (IMappedObject point) {
+        return distanceTo(point.x(), point.y());
+    }
     public static Comparator<IMappedObject> MAP_ORDER = new Comparator<IMappedObject>() {
         @Override
         public int compare(IMappedObject o1, IMappedObject o2) {

--- a/src/rotp/ui/races/RacesMilitaryUI.java
+++ b/src/rotp/ui/races/RacesMilitaryUI.java
@@ -548,7 +548,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         int sw = g.getFontMetrics().stringWidth(s);
         int x1 = x+((x0-x-sw)/2);
         int y1 = y+(h/2)-s10;
-        if view.canDistinguishFromOtherDesigns()
+        if (view.canDistinguishFromOtherDesigns())
             drawShadowedString(g, s, 1, x1, y1, SystemPanel.blackText, c0);
 
         nameBox.setBounds(x1-s5,y1-s18,sw+s10,s22);

--- a/src/rotp/ui/races/RacesMilitaryUI.java
+++ b/src/rotp/ui/races/RacesMilitaryUI.java
@@ -510,7 +510,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         int x3 = x+scaled(550);
         int x4 = x+scaled(735);
         int x5 = x+w-scaled(20);
-        
+
         drawShipNameAndIcon(g, view, x0, y, x1-x0, h);
         drawShipTactical1(g, view, x1, y, x2-x1, h);
         drawShipTactical2(g, view, x2, y, x3-x2, h);
@@ -535,7 +535,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         int h0 = h-s10;
         
         ShipDesign d = view.design();
-        
+
         if (!renameBoxes.containsKey(d))
             renameBoxes.put(d, new Rectangle());
         Rectangle nameBox = renameBoxes.get(d);
@@ -543,13 +543,14 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         Color c0 = hoverNameBox == nameBox ? SystemPanel.yellowText : SystemPanel.whiteText;
         
         g.setFont(narrowFont(20));
-        String s = d.name();
+        String s = view.reportingName();
         scaledFont(g,s,w0-s10,20,10);
         int sw = g.getFontMetrics().stringWidth(s);
         int x1 = x+((x0-x-sw)/2);
         int y1 = y+(h/2)-s10;
-        drawShadowedString(g, s, 1, x1, y1, SystemPanel.blackText, c0);
-        
+        if view.canDistinguishFromOtherDesigns()
+            drawShadowedString(g, s, 1, x1, y1, SystemPanel.blackText, c0);
+
         nameBox.setBounds(x1-s5,y1-s18,sw+s10,s22);
         
         String status, status2 = null;
@@ -631,7 +632,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         drawString(g,label,  x0, y3);
              
         g.setFont(narrowFont(15));
-        String val = d.sizeDesc();
+        String val = view.sizeKnown() ? sd.sizeDesc() : unk;
         int sw = g.getFontMetrics().stringWidth(val);
         drawString(g,val, x+w-sw-s10, y0);
         val = view.armorKnown() ? str((int)d.hits()) : unk;
@@ -640,7 +641,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         val =  view.shieldKnown() ? str((int)d.shieldLevel()) : unk;
         sw = g.getFontMetrics().stringWidth(val);
         drawString(g,val, x+w-sw-s10, y2);
-        val = str(d.warpSpeed());
+        val = view.warpSpeedKnown() ? str(d.warpSpeed()) : unk;
         sw = g.getFontMetrics().stringWidth(val);
         drawString(g,val, x+w-sw-s10, y3);
     }

--- a/src/rotp/ui/races/RacesMilitaryUI.java
+++ b/src/rotp/ui/races/RacesMilitaryUI.java
@@ -632,7 +632,7 @@ public final class RacesMilitaryUI extends BasePanel implements MouseListener, M
         drawString(g,label,  x0, y3);
              
         g.setFont(narrowFont(15));
-        String val = view.sizeKnown() ? sd.sizeDesc() : unk;
+        String val = view.sizeKnown() ? d.sizeDesc() : unk;
         int sw = g.getFontMetrics().stringWidth(val);
         drawString(g,val, x+w-sw-s10, y0);
         val = view.armorKnown() ? str((int)d.hits()) : unk;


### PR DESCRIPTION
Lots of machinery, but this doesn't actually take the plunge and change the display.

The new function `Empire.matchShipsSeenThisTurnToShipsSeenLastTurn()` attempts to match ships visible now with ships visible last turn, using only information that the empire knows. If you know that matching, you know the vector.

I tried to brainstorm every possible reason the empire might not be totally 100% certain. E.g. if the ship is at a star system, any star system, give up immediately because the empire can't be sure that the ship wasn't built that turn.

There is one change here that touches on active code. I wanted to formalize exactly what comes with having a ShipView object, so I added public static functions to ShipView, just so that the fleet display checks a conditional for displaying the Travel Speed just like it has a conditional for everything else. This way, the fact that the Travel Speed is always visible is held in the ShipView rather than in the RacesMilitaryUI.