### PR TITLE
Draw path to suspected destination if actual destination unknown

### DIFF
--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2390,13 +2390,13 @@ public final class Empire implements Base, NamedObject, Serializable {
         // For simplicity, we completely ignore scan coverage from ships.
         return distanceTo(ufo) + maxSpeedShipMightHave(ufo) < planetScanningRange();
     }
-    public starSystemInLineIfAny(float firstX, float firstY, float secondX, float secondY) {
+    public StarSystem starSystemInLineIfAny(float firstX, float firstY, float secondX, float secondY) {
         /**
          * This function uses only information available to the empire.
          * This function should never be used to for game purposes, because when systems are collinear the answer it returns can be,
          * and sometimes will be, wrong.
          */
-        static final MAX_LOOKAHEAD = 8; // just to ensure we don't somehow infinite-loop
+        final int MAX_LOOKAHEAD = 8; // just to ensure we don't somehow infinite-loop
         float strideX = secondX - firstX;
         float strideY = secondY - firstY;
         for (int i=1; i<MAX_LOOKAHEAD; i++)

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -388,10 +388,15 @@ public class Transport implements Base, Ship, Sprite, Serializable {
             if (path != null)
                 path.draw(map, g2);
         }
-        boolean showMyPath = player().knowETA(this) && (map.showAllFlightPaths() || map.parent().isClicked(this));
 
-        if (showMyPath)
-            pathSprite().draw(map, g2);
+        if (map.showAllFlightPaths() || map.parent().isClicked(this))
+            if (player().knowETA(this))
+                pathSprite().draw(map, g2);
+            else {
+                StarSystem suspectedDestination = player().suspectedDestinationsOfVisibleShips().get(this);
+                if (suspectedDestination != null)
+                    pathSpriteTo(suspectedDestination).draw(map, g2);
+            }
     }
 
     @Override


### PR DESCRIPTION
This allows an empire without Improved Space Scanner that sees a ship on two successive turns (in a situation where it's impossible to get mixed up with any other ship) to "walk it forward" to see where it's going to be in a few turns.

Note that while the displayed vector is always "correct" in the sense that the ship really is moving along that line, the displayed line segment always *stops* at the first star system that crosses its path, whereas the ship might in fact bypass that star system at warp. (It cannot know whether that star is the actual destination, because the empire doesn't know the actual destination.) I'm not *too* worried about that in terms of player confusion, but this does currently use the same PathSprite as known-for-sure paths. I mostly figure it's probably fine in the sense that it's not displaying anything false, the ship really is headed there, it just might not stop there.

This only touches Transport at the moment. This would obviously apply to ShipFleet as well, but before doing that I want to do more unification of Transport and ShipFleet to avoid adding yet more machinery duplicated between both, and *that* seems like it should be its own branch, since it makes major changes to two important classes but *shouldn't* change any behavior.