### PR TITLE
Fix java.lang.IllegalStateException: Duplicate key null

### DIFF
--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2346,9 +2346,14 @@ public final class Empire implements Base, NamedObject, Serializable {
         int numberOfShipsWithMissingDesign = 0;
         if (designs.containsKey(null))
             numberOfShipsWithMissingDesign = designs.get(null);
-        Map<ShipView, Integer> ret = designs.entrySet().stream().filter(Objects::nonNull).collect(Collectors.toMap(
+        Map<ShipView, Integer> ret = designs.entrySet().stream().filter(Objects::nonNull)
+                                            .collect(Collectors.toMap(
             entry -> shipViewFor(entry.getKey()),
-            Map.Entry::getValue
+            Map.Entry::getValue,
+            // Although we separately dealt with null designs, we can still have multiple null ShipViews.
+            // We agglomerate those all together and save the count in case we want it.
+            // (Collectors.toMap will complain of "Duplicate key null" if we don't include some kind of mergeFunction)
+            Integer.sum
         ));
         if (numberOfShipsWithMissingDesign > 0)
             ret.put(null, ret.get(null) + numberOfShipsWithMissingDesign);

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2353,7 +2353,7 @@ public final class Empire implements Base, NamedObject, Serializable {
             // Although we separately dealt with null designs, we can still have multiple null ShipViews.
             // We agglomerate those all together and save the count in case we want it.
             // (Collectors.toMap will complain of "Duplicate key null" if we don't include some kind of mergeFunction)
-            Integer.sum
+            Integer::sum
         ));
         if (numberOfShipsWithMissingDesign > 0)
             ret.put(null, ret.get(null) + numberOfShipsWithMissingDesign);

--- a/src/rotp/model/game/IInGameOptions.java
+++ b/src/rotp/model/game/IInGameOptions.java
@@ -184,8 +184,7 @@ public interface IInGameOptions extends IConvenienceOptions {
 
 	ParamBoolean trackUFOsAcrossTurns = new ParamBoolean(MOD_UI, "TRACK_UFOS_ACROSS_TURNS", true);
 	
-	default boolean selectedTrackUFOsAcrossTurns() { return false; }
-// TODO	default boolean selectedTrackUFOsAcrossTurns() { return trackUFOsAcrossTurns.get(); }
+	default boolean selectedTrackUFOsAcrossTurns() { return trackUFOsAcrossTurns.get(); }
 	
 	// ==================== GUI List Declarations ====================
 	LinkedList<IParam> modOptionsDynamicA = new LinkedList<>(
@@ -196,8 +195,7 @@ public interface IInGameOptions extends IConvenienceOptions {
 				null,
 				bombingTarget, targetBombard, flagColorCount, autoFlagOptionsUI,
 				null,
-				scrapRefundFactor, scrapRefundOption, autoTerraformEnding
-// TODO				scrapRefundFactor, scrapRefundOption, autoTerraformEnding, trackUFOsAcrossTurns
+				scrapRefundFactor, scrapRefundOption, autoTerraformEnding, trackUFOsAcrossTurns
 			));
 	LinkedList<IParam> modOptionsDynamicB = new LinkedList<>(
 			Arrays.asList(

--- a/src/rotp/model/game/IModOptions.java
+++ b/src/rotp/model/game/IModOptions.java
@@ -133,8 +133,7 @@ public interface IModOptions extends IFlagOptions, IPreGameOptions, IInGameOptio
 				headerSpacer,
 				new ParamTitle("GAME_OTHER"),
 				showAlliancesGNN, showLimitedWarnings,
-				techExchangeAutoRefuse, autoTerraformEnding, autoplay
-// TODO				techExchangeAutoRefuse, autoTerraformEnding, trackUFOsAcrossTurns, autoplay
+				techExchangeAutoRefuse, autoTerraformEnding, trackUFOsAcrossTurns, autoplay
 				)));
 		map.add(new LinkedList<>(Arrays.asList(
 				new ParamTitle("GAME_RELATIONS"),


### PR DESCRIPTION
I can reproduce the crash using the attached [duplicateKeyNull.zip](https://github.com/BrokenRegistry/Rotp-Fusion/files/11991383/duplicateKeyNull.zip) (which I took the liberty of renaming) by re-enabling the option.

The crash does not happen on this branch.

(I'm still a little concerned that I have no theory for why the crash happens in this particular situation; looking at the code it's obvious that a crash can sometimes happen, but it seems like the crash should only happen when there's a fleet with multiple ships that lack ShipViews, whereas it seems like all the visible ships here should have ShipViews. Hrm.)