### PR TITLE
Move common features of ShipFleet and Transport into base class

### DIFF
--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,5 +1,7 @@
 package rotp.model.galaxy;
 
+import rotp.ui.main.GalaxyMapPanel;
+
 public abstract class FleetBase {
   private static final long serialVersionUID = 1L;
   private float arrivalTime = Float.MAX_VALUE;
@@ -13,7 +15,7 @@ public abstract class FleetBase {
   }
 
   public boolean displayed() { return displayed; }
-  protected abstract boolean decideWhetherDisplayed();
+  protected abstract boolean decideWhetherDisplayed(GalaxyMapPanel map);
   public void setDisplayed() {
     displayed = decideWhetherDisplayed();
   }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -5,4 +5,8 @@ public abstract class FleetBase {
   private float arrivalTime = Float.MAX_VALUE;
 
   public float arrivalTime() { return arrivalTime; }
+  abstract float calculateArrivalTime();
+  public void setArrivalTime() {
+    arrivalTime = calculateArrivalTime();
+  }
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -16,7 +16,7 @@ public abstract class FleetBase {
 
   public boolean displayed() { return displayed; }
   protected abstract boolean decideWhetherDisplayed(GalaxyMapPanel map);
-  public void setDisplayed() {
-    displayed = decideWhetherDisplayed();
+  public void setDisplayed(GalaxyMapPanel map) {
+    displayed = decideWhetherDisplayed(map);
   }
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,5 +1,5 @@
 package rotp.model.galaxy;
 
-public class FleetBase {
+public abstract class FleetBase {
   private static final long serialVersionUID = 1L;
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,6 +1,7 @@
 package rotp.model.galaxy;
 
 import rotp.ui.main.GalaxyMapPanel;
+import rotp.util.Base;
 
 public abstract class FleetBase implements Base {
   private static final long serialVersionUID = 1L;

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -2,4 +2,7 @@ package rotp.model.galaxy;
 
 public abstract class FleetBase {
   private static final long serialVersionUID = 1L;
+  private float arrivalTime = Float.MAX_VALUE;
+
+  public float arrivalTime() { return arrivalTime; }
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -12,7 +12,12 @@ public abstract class FleetBase implements Base {
   private transient Rectangle selectBox;
   private transient boolean hovering;
 
-  public float arrivalTime() { return arrivalTime; }
+  public float arrivalTime() {
+    if (arrivalTime == Float.MAX_VALUE) {
+      throw new RuntimeException("Something has gone terribly wrong: setArrivalTime() was never called, or it returned Float.MAX_VALUE.");
+    }
+    return arrivalTime;
+  }
   protected abstract float calculateArrivalTime();
   public void setArrivalTime() {
     arrivalTime = calculateArrivalTime();

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -4,9 +4,17 @@ public abstract class FleetBase {
   private static final long serialVersionUID = 1L;
   private float arrivalTime = Float.MAX_VALUE;
 
+  private transient boolean displayed;
+
   public float arrivalTime() { return arrivalTime; }
-  abstract float calculateArrivalTime();
+  protected abstract float calculateArrivalTime();
   public void setArrivalTime() {
     arrivalTime = calculateArrivalTime();
+  }
+
+  public boolean displayed() { return displayed; }
+  protected abstract boolean decideWhetherDisplayed();
+  public void setDisplayed() {
+    displayed = decideWhetherDisplayed();
   }
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,10 +1,11 @@
 package rotp.model.galaxy;
 
 import java.awt.Rectangle;
+import java.io.Serializable;
 import rotp.ui.main.GalaxyMapPanel;
 import rotp.util.Base;
 
-public abstract class FleetBase implements Base {
+public abstract class FleetBase implements Base, Serializable {
   private static final long serialVersionUID = 1L;
   private float arrivalTime = Float.MAX_VALUE;
 

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,0 +1,3 @@
+public class FleetBase {
+  private static final long serialVersionUID = 1L;
+}

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,3 +1,5 @@
+package rotp.model.galaxy;
+
 public class FleetBase {
   private static final long serialVersionUID = 1L;
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -14,13 +14,16 @@ public abstract class FleetBase implements Base {
 
   public float arrivalTime() {
     if (arrivalTime == Float.MAX_VALUE) {
-      throw new RuntimeException("Something has gone terribly wrong: setArrivalTime() was never called, or it returned Float.MAX_VALUE.");
+      throw new RuntimeException("Something has gone terribly wrong: it appears setArrivalTime() was never called.");
     }
     return arrivalTime;
   }
   protected abstract float calculateArrivalTime();
   public void setArrivalTime() {
     arrivalTime = calculateArrivalTime();
+    if (arrivalTime == Float.MAX_VALUE) {
+      throw new RuntimeException("Something has gone terribly wrong: calculateArrivalTime() returned Float.MAX_VALUE.");
+    }
   }
 
   public boolean displayed() { return displayed; }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -1,5 +1,6 @@
 package rotp.model.galaxy;
 
+import java.awt.Rectangle;
 import rotp.ui.main.GalaxyMapPanel;
 import rotp.util.Base;
 

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -2,12 +2,13 @@ package rotp.model.galaxy;
 
 import rotp.ui.main.GalaxyMapPanel;
 
-public abstract class FleetBase {
+public abstract class FleetBase implements Base {
   private static final long serialVersionUID = 1L;
   private float arrivalTime = Float.MAX_VALUE;
 
   private transient boolean displayed;
   private transient Rectangle selectBox;
+  private transient boolean hovering;
 
   public float arrivalTime() { return arrivalTime; }
   protected abstract float calculateArrivalTime();
@@ -26,4 +27,7 @@ public abstract class FleetBase {
       selectBox = new Rectangle();
     return selectBox;
   }
+
+  public boolean hovering()                   { return hovering; }
+  public void hovering(boolean b)             { hovering = b; }
 }

--- a/src/rotp/model/galaxy/FleetBase.java
+++ b/src/rotp/model/galaxy/FleetBase.java
@@ -7,6 +7,7 @@ public abstract class FleetBase {
   private float arrivalTime = Float.MAX_VALUE;
 
   private transient boolean displayed;
+  private transient Rectangle selectBox;
 
   public float arrivalTime() { return arrivalTime; }
   protected abstract float calculateArrivalTime();
@@ -18,5 +19,11 @@ public abstract class FleetBase {
   protected abstract boolean decideWhetherDisplayed(GalaxyMapPanel map);
   public void setDisplayed(GalaxyMapPanel map) {
     displayed = decideWhetherDisplayed(map);
+  }
+
+  public Rectangle selectBox() {
+    if (selectBox == null)
+      selectBox = new Rectangle();
+    return selectBox;
   }
 }

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -38,6 +38,7 @@ public interface Ship extends IMappedObject, Base, Sprite {
     default boolean hasDisplayPanel() { return true; }
 
     public boolean canSendTo(int sysId);
+    public float travelSpeed();
     public float launchTime();
     public float arrivalTime();
     public boolean visibleTo(int empId);

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -82,6 +82,7 @@ public interface Ship extends IMappedObject, Base, Sprite {
     }
 
     public boolean inTransit();
+    default int travelTurnsRemaining() { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime() - galaxy().currentTime()); }
     @Override // from IMappedObject
     default float x() { return inTransit() ? transitX() : fromX(); }
     @Override // from IMappedObject

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -53,7 +53,9 @@ public interface Ship extends IMappedObject, Base, Sprite {
     public int empId();
     default Empire empire() { return galaxy().empire(empId()); }
     public int destSysId();
-    default StarSystem destination() { return galaxy().system(destSysId());  }
+    default StarSystem destination() { return galaxy().system(destSysId()); }
+    // Rally systems are treated differently from other destinations, but sometimes we just want either one.
+    default StarSystem destinationOrRallySystem() { return destination(); }
     default float destX() { return destination().x(); }
     default float destY() { return destination().y(); }
     // destination is always a star system, but origin point need not be?

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -84,7 +84,8 @@ public interface Ship extends IMappedObject, Base, Sprite {
     }
 
     public boolean inTransit();
-    default int travelTurnsRemaining() { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime() - galaxy().currentTime()); }
+    // This default travelTurnsRemaining() assumes that arrivalTime is always well-defined even if the Ship is not in transit (as it is for ShipFleet).
+    default int travelTurnsRemaining() { return (int)Math.ceil(arrivalTime() - galaxy().currentTime()); }
     @Override // from IMappedObject
     default float x() { return inTransit() ? transitX() : fromX(); }
     @Override // from IMappedObject

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -69,6 +69,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
             StarSystem s = galaxy().system(destSysId);
             destX = s.x();
             destY = s.y();
+            setArrivalTime();
         }
     }
     public void destination(int i, float x, float y) {

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -41,7 +41,7 @@ import rotp.ui.map.IMapHandler;
 import rotp.ui.sprites.FlightPathSprite;
 import rotp.util.Base;
 
-public class ShipFleet implements Base, Sprite, Ship, Serializable {
+public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializable {
     private static final long serialVersionUID = 1L;
     enum Status { ORBITING, DEPLOYED, IN_TRANSIT, RETREAT_ON_ARRIVAL };
     public final int empId;

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -217,6 +217,8 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         if (pathSprite == null)
             pathSprite = new FlightPathSprite(this, dest);
         if (pathSprite.destination() != dest)
+            // Under what possible circumstances could this ever happen?
+            // The FlightPathSprite constructor sets its destination to the second argument. That's all it does.
             pathSprite.destination(dest);
         return pathSprite;
     }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -1029,7 +1029,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
             return GalaxyMapPanel.MAX_FLEET_SMALL_SCALE;
     }
     @Override
-    public void decideWhetherDisplayed(GalaxyMapPanel map) {
+    public boolean decideWhetherDisplayed(GalaxyMapPanel map) {
         if (!map.displays(this))
             return false;
         if (map.scaleX() > maxMapScale())

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -205,7 +205,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         destY = fl.destY;
     }
     @Override
-    public destinationOrRallySystem() {
+    public StarSystem destinationOrRallySystem() {
         int destId = hasDestination() ? destSysId : rallySysId;
         if (destId == StarSystem.NULL_ID)
             return null;

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -207,13 +207,17 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
     @Override
     public StarSystem destinationOrRallySystem() {
         int destId = hasDestination() ? destSysId : rallySysId;
-        if (destId == StarSystem.NULL_ID)
-            return null;
+        // galaxy().system(destId) will return null if destId is StarSystem.NULL_ID
+        // if (destId == StarSystem.NULL_ID)
+        //     return null;
         return galaxy().system(destId);
     }
     @Override
     public FlightPathSprite pathSprite() {
         StarSystem dest = destinationOrRallySystem();
+        // If we have no destination and no rally system, we have no path and no path sprite.
+        if (dest == null)
+            return null;
         if (pathSprite == null)
             pathSprite = new FlightPathSprite(this, dest);
         if (pathSprite.destination() != dest)

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -54,7 +54,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
     private boolean retreating = false;
     private float fromX, fromY, destX, destY;
     private float launchTime = NOT_LAUNCHED;
-    private float arrivalTime = Float.MAX_VALUE;
 
     private transient FleetOrders orders;
     private transient FlightPathSprite pathSprite;
@@ -143,8 +142,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
 
     @Override
     public int empId()                  { return empId; }
-    @Override
-    public float arrivalTime()         { return arrivalTime; }
     @Override
     public boolean visibleTo(int emp) {
         if (emp == empId)
@@ -529,12 +526,13 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
     public boolean hasShip(ShipDesign d)  {
             return (d == null) || !d.active() ? false : num[d.id()] > 0;
     }
-    public void setArrivalTime() {
-        arrivalTime = galaxy().currentTime();
+    public float calculateArrivalTime() {
+        float arrivalTime = galaxy().currentTime();
         if (hasDestination())
             arrivalTime += travelTime(destination());
         if (arrivalTime <= galaxy().currentTime()) 
             log("Error: ship arrivalTime <= currentTime");
+        return arrivalTime;
     }
     public FleetOrders newOrders() {
         if (orders == null)
@@ -731,7 +729,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         return currTurns+nextTurns;
     }
     public int travelTurnsRemaining()     { 
-        return (int)Math.ceil(arrivalTime - galaxy().currentTime());
+        return (int)Math.ceil(arrivalTime() - galaxy().currentTime());
     }
     public int numScouts()   { return numShipType(ShipDesign.SCOUT); }
     public int numFighters() { return numShipType(ShipDesign.FIGHTER); }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -57,7 +57,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
 
     private transient FleetOrders orders;
     private transient FlightPathSprite pathSprite;
-    private transient Rectangle selectBox;
     private transient boolean hovering;
     private transient int[] bombardCount = new int[ShipDesignLab.MAX_DESIGNS];
 
@@ -133,12 +132,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
     }
     public boolean hasDestination()     { return destSysId != StarSystem.NULL_ID; }
     
-    public Rectangle selectBox() {
-        if (selectBox == null)
-            selectBox = new Rectangle();
-        return selectBox;
-    }
-
     @Override
     public int empId()                  { return empId; }
     @Override

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -639,6 +639,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         }
         return empire().tech().scoutRange();
     }
+    public float travelSpeed() { return slowestStackSpeed(); }
     public float slowestStackSpeed() {
         float maxSpeed = Integer.MAX_VALUE;
         for (int i=0;i<num.length;i++) {
@@ -689,7 +690,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         return empire().sv.withinRange(dest.id, range());
     }
     public float travelTime(StarSystem to) {
-        return travelTime(to, slowestStackSpeed());
+        return travelTime(to, travelSpeed());
     }
     public float travelTime(StarSystem dest, float speed) {
         if (inOrbit() || deployed()

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -728,9 +728,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         int nextTurns = (int) Math.ceil(travelTime(currDest,finalDest,design.warpSpeed()));
         return currTurns+nextTurns;
     }
-    public int travelTurnsRemaining()     { 
-        return (int)Math.ceil(arrivalTime() - galaxy().currentTime());
-    }
     public int numScouts()   { return numShipType(ShipDesign.SCOUT); }
     public int numFighters() { return numShipType(ShipDesign.FIGHTER); }
     public int numBombers()  { return numShipType(ShipDesign.BOMBER); }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -57,7 +57,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
 
     private transient FleetOrders orders;
     private transient FlightPathSprite pathSprite;
-    private transient boolean hovering;
     private transient int[] bombardCount = new int[ShipDesignLab.MAX_DESIGNS];
 
     public int sysId()                  { return sysId; }
@@ -146,10 +145,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         }
         return false;
     }
-    @Override
-    public boolean hovering()                   { return hovering; }
-    @Override
-    public void hovering(boolean b)             { hovering = b; }
     public ShipFleet(int emp, StarSystem s) {
         empId = emp;
         sysId = s.id;

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -73,7 +73,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         }
     }
     public void destination(int i, float x, float y) {
-        destSysId = i;
+        destSysId(i);
         destX = x;
         destY = y;
     }
@@ -188,7 +188,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         sysId = f.sysId;
         fromX = f.x();
         fromY = f.y();
-        destSysId = f.destSysId;
+        destSysId(f.destSysId);
         destX = f.destX;
         destY = f.destY;
         status = f.status;
@@ -201,7 +201,7 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         sysId = fl.sysId;
         fromX = fl.fromX;
         fromY = fl.fromY;
-        destSysId = fl.destSysId;
+        destSysId(fl.destSysId);
         destX = fl.destX;
         destY = fl.destY;
     }

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -205,11 +205,15 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
         destY = fl.destY;
     }
     @Override
-    public FlightPathSprite pathSprite() {
+    public destinationOrRallySystem() {
         int destId = hasDestination() ? destSysId : rallySysId;
         if (destId == StarSystem.NULL_ID)
             return null;
-        StarSystem dest = galaxy().system(destId);
+        return galaxy().system(destId);
+    }
+    @Override
+    public FlightPathSprite pathSprite() {
+        StarSystem dest = destinationOrRallySystem();
         if (pathSprite == null)
             pathSprite = new FlightPathSprite(this, dest);
         if (pathSprite.destination() != dest)

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -55,7 +55,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     private String troopBattleSuitId;
     private String troopWeaponId;
     private String troopShieldId;
-    private transient boolean displayed;
     private transient Rectangle selectBox;
     private transient boolean hovering;
     private transient FlightPathSprite pathSprite;
@@ -71,8 +70,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     public boolean hovering()                   { return hovering; }
     @Override
     public void hovering(boolean b)             { hovering = b; }
-    @Override
-    public boolean displayed()                  { return displayed; }
     @Override
     public int displayPriority()                { return 8; }
     @Override
@@ -335,21 +332,20 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     @Override
     public int maxMapScale()                    { return GalaxyMapPanel.MAX_FLEET_TRANSPORT_SCALE;  }
     @Override
-    public void setDisplayed(GalaxyMapPanel map) {
-        displayed = false;
+    public void decideWhetherDisplayed(GalaxyMapPanel map) {
         if (!map.parent().isClicked(this)) {
             if ((empire == targetEmp) && !map.showFriendlyTransports())
-                return;
+                return false;
             if ((empire != targetEmp) && !map.showArmedShips())
-                return;
+                return false;
         }
         if (map.scaleX() > maxMapScale())
-            return;
-        displayed = true;
+            return false;
+        return true;
     }
     @Override
     public void draw(GalaxyMapPanel map, Graphics2D g2) {
-        if (!displayed)
+        if (!displayed())
             return;
         int x = mapX(map);
         int y = mapY(map);

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -125,7 +125,8 @@ public class Transport implements Base, Ship, Sprite, Serializable {
     public float combatAdj()          { return combatAdj; }
     @Override
     public float launchTime()         { return launchTime; }
-    public Empire targetCiv()          { return targetEmp; }
+    public Empire targetCiv()         { return targetEmp; }
+    public float travelSpeed()        { return travelSpeed; }
     public void travelSpeed(float d)  { travelSpeed = d; }
 
 

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -229,6 +229,11 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
         }
         return normalTime;
     }
+    @Override
+    // Why does Transport.travelTurnsRemaining() check whether it's inTransit?
+    // It sort of works, since Transports don't have a "deployed, not in transit" state like ShipFleet,
+    // but a Transport is only not inTransit when dest == null, and when could that ever happen?
+    public int travelTurnsRemaining()     { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime-galaxy().currentTime()); }
     public float calculateArrivalTime() {
         // direct time is if we go straight there at empire's tech transport speed
         float directTime = travelTime(dest);

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -55,7 +55,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     private String troopBattleSuitId;
     private String troopWeaponId;
     private String troopShieldId;
-    private transient boolean hovering;
     private transient FlightPathSprite pathSprite;
     private transient StarSystem hoveringDest;
 
@@ -65,10 +64,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     private TechBattleSuit troopBattleSuit() { return (TechBattleSuit) tech(troopBattleSuitId); }
     private TechHandWeapon troopWeapon()     { return (TechHandWeapon) tech(troopWeaponId); }
     private TechPersonalShield troopShield() { return (TechPersonalShield) tech(troopShieldId); }
-    @Override
-    public boolean hovering()                   { return hovering; }
-    @Override
-    public void hovering(boolean b)             { hovering = b; }
     @Override
     public int displayPriority()                { return 8; }
     @Override

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -35,7 +35,7 @@ import rotp.ui.notifications.TransportsPerishedAlert;
 import rotp.ui.sprites.FlightPathSprite;
 import rotp.util.Base;
 
-public class Transport implements Base, Ship, Sprite, Serializable {
+public class Transport extends FleetBase implements Base, Ship, Sprite, Serializable {
     private static final long serialVersionUID = 1L;
     private Empire empire;
     private final StarSystem from;

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -55,7 +55,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     private String troopBattleSuitId;
     private String troopWeaponId;
     private String troopShieldId;
-    private transient Rectangle selectBox;
     private transient boolean hovering;
     private transient FlightPathSprite pathSprite;
     private transient StarSystem hoveringDest;
@@ -86,11 +85,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
             orderToSurrenderOnArrival();
     }
 
-    public Rectangle selectBox() {
-        if (selectBox == null)
-            selectBox = new Rectangle();
-        return selectBox;
-    }
     @Override
     public FlightPathSprite pathSprite() {
         if (pathSprite == null)

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -50,7 +50,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     private float combatAdj = 0;
     private float launchTime = NOT_LAUNCHED;
     private float travelSpeed = 0;
-    private float arrivalTime = Float.MAX_VALUE;
 
     private String troopArmorId;
     private String troopBattleSuitId;
@@ -139,8 +138,6 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     public int destSysId()              { return dest == null ? StarSystem.NULL_ID : dest.id; }
     @Override
     public int empId()                  { return empire.id; }
-    @Override
-    public float arrivalTime()         { return arrivalTime; }
     public void arrive()                { dest.acceptTransport(this); }
     @Override
     public boolean visibleTo(int empId) { return true; }
@@ -246,14 +243,13 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
         }
         return normalTime;
     }
-    public int travelTurnsRemaining()     { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime-galaxy().currentTime()); }
-    public void setArrivalTime() {
+    public float calculateArrivalTime() {
         // direct time is if we go straight there at empire's tech transport speed
         float directTime = travelTime(dest);
         // set time is if we have travelSpeed alrady set, by synching transports
         float setTime = travelSpeed > 0 ? distanceTo(dest)/travelSpeed : directTime;
         // take the worst time
-        arrivalTime = galaxy().currentTime() + max(setTime, directTime);
+        return galaxy().currentTime() + max(setTime, directTime);
     }
     public boolean  changeDestination(StarSystem to) {
         if (inTransit()

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -233,7 +233,7 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     // Why does Transport.travelTurnsRemaining() check whether it's inTransit?
     // It sort of works, since Transports don't have a "deployed, not in transit" state like ShipFleet,
     // but a Transport is only not inTransit when dest == null, and when could that ever happen?
-    public int travelTurnsRemaining()     { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime-galaxy().currentTime()); }
+    public int travelTurnsRemaining()     { return !inTransit() ? 0 : (int)Math.ceil(arrivalTime()-galaxy().currentTime()); }
     public float calculateArrivalTime() {
         // direct time is if we go straight there at empire's tech transport speed
         float directTime = travelTime(dest);

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -95,7 +95,10 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     public String toString()          { return concat("Transport: ", Integer.toHexString(hashCode())); }
     public Colony home()              { return from.colony(); }
     public StarSystem destination()   { return dest; }
-    public void setDest(StarSystem d) { dest = d; }
+    public void setDest(StarSystem d) {
+        dest = d;
+        setArrivalTime();
+    }
     public StarSystem from()          { return from; }
     @Override
     public float fromX()              { return from.x(); }
@@ -245,9 +248,8 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     public boolean  changeDestination(StarSystem to) {
         if (inTransit()
         && validDestination(id(to))) {
-            dest = to;
+            setDest(to);
             targetEmp = to.empire();
-            setArrivalTime();
             return true;
         }
         return false;

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -332,7 +332,7 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
     @Override
     public int maxMapScale()                    { return GalaxyMapPanel.MAX_FLEET_TRANSPORT_SCALE;  }
     @Override
-    public void decideWhetherDisplayed(GalaxyMapPanel map) {
+    public boolean decideWhetherDisplayed(GalaxyMapPanel map) {
         if (!map.parent().isClicked(this)) {
             if ((empire == targetEmp) && !map.showFriendlyTransports())
                 return false;

--- a/src/rotp/ui/sprites/FlightPathSprite.java
+++ b/src/rotp/ui/sprites/FlightPathSprite.java
@@ -76,10 +76,13 @@ public class FlightPathSprite extends MapSprite {
     public FlightPathSprite()  {}
     public FlightPathSprite(Ship s, StarSystem sv) {
         ship = s;
+        assert sv != null : "FlightPathSprite created with no destination";
         to = sv;
     }
     public FlightPathSprite(StarSystem sv1, StarSystem sv2) {
+        assert sv1 != null : "FlightPathSprite created with no source";
         fr = sv1;
+        assert sv2 != null : "FlightPathSprite created with no destination";
         to = sv2;
         isColonyRelocation = true;
     }


### PR DESCRIPTION
This de-duplicates some of the common features of `ShipFleet` and `Transport` into a new base class, which I am imaginatively calling `FleetBase`. (There might be a better name.)

This also extracts `travelTurnsRemaining()` into the interface `Ship`.

(For the moment, `Ship` and `FleetBase` are technically unrelated.)

This also makes `Transport.setDest()` always call `setArrivalTime()` immediately, instead of waiting for the Transport to be launched. This *does* change governor behavior: previously the governor tried to take account of incoming transports when deciding Ecology spending, but if a transport from a neighboring colony would only take one turn to arrive, then it would never be taken account of, because the arrival time for that transport had not been set (because previously the arrival time for a Transport was only set when it was launched). However, I don't think the arrival time of a not-yet-launched transport was ever used except by the governor. In any case, if any part of the code *does* query the arrival time of a not-yet-launched transport, it seems more correct to provide the most likely arrival time, instead of Float.MAX_VALUE.