### PR TITLE
Make GalaxyMapPanel show suspected flight paths if options().selectedTrackUFOsAcrossTurns() enabled

### DIFF
--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2321,25 +2321,11 @@ public final class Empire implements Base, NamedObject, Serializable {
             return true;
         if (ufoNow.isTransport() != ufoLastTurn.isTransport())
             return true;
-        if (knowsShipCouldNotHaveReachedThisLocation(ufoNow, ufoLastTurn))
-            return true;
         if (ufoNow instanceof ShipFleet && ufoLastTurn instanceof ShipFleet)
             return knowsCouldNotHaveBeenSameFleetLastTurn((ShipFleet)ufoNow, (ShipFleet)ufoLastTurn);
         if (ufoNow instanceof Transport && ufoLastTurn instanceof Transport)
             return knowsCouldNotHaveBeenSameTransportLastTurn((Transport)ufoNow, (Transport)ufoLastTurn);
         return false;
-    }
-    public boolean knowsShipCouldNotHaveReachedThisLocation(Ship ufoNow, Ship ufoLastTurn) {
-        float maxPossibleTravelSpeed = maxSpeedShipMightHave(ufoNow);
-        // If we wanted this function to have broader uses,
-        // we could call the function on both Ships and take the minimum of the two,
-        // but in the context of trying to distinguish ships from each other,
-        // if the two UFOs are so obviously different that different amounts are known about their possible speeds,
-        // then they'll immediately be known distinct and this function will never be called.
-        float deltaX = ufoNow.x() - ufoLastTurn.transitXlastTurn();
-        float deltaY = ufoNow.y() - ufoLastTurn.transitYlastTurn();
-        float squaredDistanceMoved = deltaX*deltaX + deltaY*deltaY;
-        return squaredDistanceMoved > maxPossibleTravelSpeed*maxPossibleTravelSpeed*1.125; // allow a fudge factor
     }
     public boolean knowsTransportCouldNotHaveReachedThisLocation(Transport ufoNow, Transport ufoLastTurn) {
         float maxPossibleTravelSpeed = maxSpeedTransportMightHave(ufoNow);
@@ -2350,6 +2336,11 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public boolean knowsFleetCouldNotHaveReachedThisLocation(ShipFleet ufoNow, ShipFleet ufoLastTurn) {
         float maxPossibleTravelSpeed = maxSpeedFleetMightHave(ufoNow);
+        // If we wanted this function to have broader uses,
+        // we could call maxSpeedFleetMightHave() on both Ships and take the minimum of the two,
+        // but in the context of trying to distinguish ships from each other,
+        // if the two UFOs are so obviously different that different amounts are known about their possible speeds,
+        // then they'll immediately be known distinct and this function will never be called.
         float deltaX = ufoNow.x() - ufoLastTurn.transitXlastTurn();
         float deltaY = ufoNow.y() - ufoLastTurn.transitYlastTurn();
         float squaredDistanceMoved = deltaX*deltaX + deltaY*deltaY;
@@ -2376,6 +2367,8 @@ public final class Empire implements Base, NamedObject, Serializable {
     public boolean knowsCouldNotHaveBeenSameTransportLastTurn(Transport transportNow, Transport transportLastTurn) {
         // There is no concept of a ShipView for transports, but size is always visible.
         if (transportNow.size() != transportLastTurn.size())
+            return true;
+        if (knowsTransportCouldNotHaveReachedThisLocation(transportNow, transportLastTurn))
             return true;
         return false;
     }

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -2335,6 +2335,14 @@ public final class Empire implements Base, NamedObject, Serializable {
         return squaredDistanceMoved > maxPossibleTravelSpeed*maxPossibleTravelSpeed*1.125; // allow a fudge factor
     }
     public boolean knowsFleetCouldNotHaveReachedThisLocation(ShipFleet ufoNow, ShipFleet ufoLastTurn) {
+        if (!ufoLastTurn.inTransit())
+            // If the Ship seen last turn arrive()d this turn, then we immediately give up.
+            // Note that the Empire does not know whether the Ship seen last turn is now in orbit,
+            // (matching ships seen last turn to ships seen this turn is exactly what the Empire is trying to do),
+            // but also note that this is entirely 100% about not wanting to store the xy coordinates of ship-sightings.
+            // The squinting-at-screenshots method absolutely *can* match up ships under this condition;
+            // whether the Ship seen last turn is still in transit would be 100% irrelevant *except* that we don't want to store more data.
+            return false;
         float maxPossibleTravelSpeed = maxSpeedFleetMightHave(ufoNow);
         // If we wanted this function to have broader uses,
         // we could call maxSpeedFleetMightHave() on both Ships and take the minimum of the two,

--- a/src/rotp/model/empires/Empire.java
+++ b/src/rotp/model/empires/Empire.java
@@ -264,6 +264,7 @@ public final class Empire implements Base, NamedObject, Serializable {
     }
     public List<Ship> visibleShips()              { return visibleShips; }
     public Map<Ship, StarSystem> suspectedDestinationsOfVisibleShips()  { return suspectedDestinationsOfVisibleShips; }
+    public StarSystem suspectedDestinationOfVisibleShip(Ship sh)  { return suspectedDestinationsOfVisibleShips().get(sh); }
     public EmpireView[] empireViews()             { return empireViews; }
     public List<StarSystem> newSystems()          { return newSystems; }
     public int lastCouncilVoteEmpId()             { return lastCouncilVoteEmpId; }

--- a/src/rotp/model/empires/ShipView.java
+++ b/src/rotp/model/empires/ShipView.java
@@ -95,6 +95,12 @@ public class ShipView implements Base,Serializable {
         else
             return 9;
     }
+    public float minPossibleWarpSpeed() {
+        if (warpSpeedKnown())
+            return design.warpSpeed();
+        else
+            return 1;
+    }
 
     public boolean hasComputer()        { return computer != null; }
     public boolean computerKnown()      { return computerKnown; }

--- a/src/rotp/model/galaxy/Ship.java
+++ b/src/rotp/model/galaxy/Ship.java
@@ -93,6 +93,9 @@ public interface Ship extends IMappedObject, Base, Sprite {
 
     public boolean deployed();
     public FlightPathSprite pathSprite();
+    default FlightPathSprite pathSpriteTo(StarSystem sys) {
+        return new FlightPathSprite(this, sys);
+    }
     public int maxMapScale();
     public void setDisplayed(GalaxyMapPanel map);
     public boolean displayed();

--- a/src/rotp/model/galaxy/ShipFleet.java
+++ b/src/rotp/model/galaxy/ShipFleet.java
@@ -938,9 +938,6 @@ public class ShipFleet extends FleetBase implements Base, Sprite, Ship, Serializ
     // Fleet Sprite behavior is here now
     public final static Comparator<ShipFleet> DEST_Y = (ShipFleet o1, ShipFleet o2) -> Base.compare(o1.destY(), o2.destY());
     public final static Comparator<ShipFleet> COST = (ShipFleet o1, ShipFleet o2) -> Base.compare(o2.bcValue(), o1.bcValue());
-    public FlightPathSprite pathSpriteTo(StarSystem sys) {
-        return new FlightPathSprite(this, sys);
-    }
     public void use(Sprite o, IMapHandler ui) {
         if (o instanceof StarSystem) {
             StarSystem sys = (StarSystem) o;

--- a/src/rotp/model/galaxy/Transport.java
+++ b/src/rotp/model/galaxy/Transport.java
@@ -416,7 +416,4 @@ public class Transport extends FleetBase implements Base, Ship, Sprite, Serializ
         g.drawRoundRect(x,y,w,h, cnr, cnr);
         g.setStroke(prev);
     }
-    private FlightPathSprite pathSpriteTo(StarSystem sys) {
-        return new FlightPathSprite(this, sys);
-    }
 }

--- a/src/rotp/ui/main/GalaxyMapPanel.java
+++ b/src/rotp/ui/main/GalaxyMapPanel.java
@@ -838,14 +838,15 @@ public class GalaxyMapPanel extends BasePanel implements IMapOptions, ActionList
             if (sh.displayed()) {
                 Sprite spr = (Sprite) sh;
                 // if we are drawing the ship, then check if its flight path should be drawn first
-                if (pl.knowETA(sh) && (sh.deployed() || sh.retreating() || sh.inTransit() || sh.isRallied())
+                if ((sh.deployed() || sh.retreating() || sh.inTransit() || sh.isRallied())
                 && parent.shouldDrawSprite(sh.pathSprite())) {
-                    sh.pathSprite().draw(this,g);
-                }
-                else if (options().selectedTrackUFOsAcrossTurns()) {
-                    StarSystem suspectedDestination = player().suspectedDestinationOfVisibleShip(sh);
-                    if (suspectedDestination != null)
-                        sh.pathSpriteTo(suspectedDestination).draw(this, g);
+                    if (pl.knowETA(sh))
+                        sh.pathSprite().draw(this,g);
+                    else if (options().selectedTrackUFOsAcrossTurns()) {
+                        StarSystem suspectedDestination = player().suspectedDestinationOfVisibleShip(sh);
+                        if (suspectedDestination != null)
+                            sh.pathSpriteTo(suspectedDestination).draw(this, g);
+                    }
                 }
                 spr.draw(this, g);
             }

--- a/src/rotp/ui/main/GalaxyMapPanel.java
+++ b/src/rotp/ui/main/GalaxyMapPanel.java
@@ -842,6 +842,11 @@ public class GalaxyMapPanel extends BasePanel implements IMapOptions, ActionList
                 && parent.shouldDrawSprite(sh.pathSprite())) {
                     sh.pathSprite().draw(this,g);
                 }
+                else if (options().selectedTrackUFOsAcrossTurns()) {
+                    StarSystem suspectedDestination = player().suspectedDestinationOfVisibleShip(sh);
+                    if (suspectedDestination != null)
+                        sh.pathSpriteTo(suspectedDestination).draw(this, g);
+                }
                 spr.draw(this, g);
             }
         }


### PR DESCRIPTION
Still only flight paths to player colonies, for now. Still, this shows flight paths without the player needing to click a specific ship, so this is now a noticeable change to gameplay; it'll jump out at you.

You can see here how some, but not all, flight paths are displayed:
![transport33nopathyet](https://github.com/BrokenRegistry/Rotp-Fusion/assets/13223511/de9b2554-e39b-491d-9f88-aace6dcda898)
The highlighted transport is the only transport of size 33 in Deep Space Scanner range, but it only entered scanner range this turn, so its trajectory is not yet known. Next turn, its trajectory is known:
![transport33nowpath](https://github.com/BrokenRegistry/Rotp-Fusion/assets/13223511/835eb34e-daea-4cb2-bfd3-9dd387cf826b)
Meanwhile three more transports have just passed into Deep Space Scanner range on the right, but their flight paths are not yet shown, just as the 33 transport didn't have a known trajectory last turn.

(You can also see here that this still doesn't show the destination in the transport panel on the right; I'm not sure whether I'm at peace with using the regular ETA text or whether I should make a special "We think the destination is such-and-such but technically this is just a guess and it might actually pass by such-and-such to a destination further along." In normal galaxy shapes I think it will basically never come up, but there's probably some galaxy shape with a ton of collinear systems so that the guesses would be often wrong.)

This also moves the `pathSpriteTo()` function up to be a default in `Ship`; this function was 100% identical between `Transport` and `ShipFleet`, except for being `private` in `Transport`.