### PR TITLE
Display refit+needed/over in industry spending slider plus swap to maxRobotControls

### DIFF
--- a/src/rotp/model/colony/ColonyIndustry.java
+++ b/src/rotp/model/colony/ColonyIndustry.java
@@ -374,7 +374,7 @@ public class ColonyIndustry extends ColonySpendingCategory {
         float builtFactories = factories;
         int colonyControls = robotControls;
         float expectedMissingPopulation = planet().currentSize() - expectedPopulation();
-        float notTobuild = expectedMissingPopulation * tech().topRobotControls();
+        float notTobuild = expectedMissingPopulation * maxRobotControls();
         builtFactories += notTobuild;
 
         float totalCost = 0;
@@ -451,14 +451,15 @@ public class ColonyIndustry extends ColonySpendingCategory {
     	float maxFactories	     = maxBuildableFactories();
     	float upcomingFactories  = upcomingFactories();
     	float maxNeededFactories = maxFactories - factories - upcomingFactories;
-    	float neededFactories    = maxNeededFactories - expectedMissingPopulation * robotControls;
-    	Float factoryBalance     = -neededFactories;
- 
+	float neededFactories    = maxNeededFactories - expectedMissingPopulation * maxRobotControls();
+	float factoryBalance     = -neededFactories;
+	Float refitFlag = 0f;
+
     	if (robotControls != tech().topRobotControls()
     			|| convertableAlienFactories() != 0) { // check for refit
-        	factoryBalance = null;
+		refitFlag = null;
     	}
-    	return new Float[] {factoryBalance, upcomingFactories, neededFactories, factories, maxFactories};
+	return new Float[] {factoryBalance, refitFlag};
     }
     //
     // PRIVATE METHODS

--- a/src/rotp/ui/main/EmpireColonySpendingPane.java
+++ b/src/rotp/ui/main/EmpireColonySpendingPane.java
@@ -315,35 +315,24 @@ public class EmpireColonySpendingPane extends BasePanel {
             if (category == Colony.INDUSTRY)  {
             	ColonyIndustry industry = colony.industry();
             	Float[] factoryBalance = industry.factoryBalance();
-            	Float balance	= factoryBalance[0];
-            	// float upcoming	= factoryBalance[1];
-            	// float needed	= factoryBalance[2];
-            	// float factories	= factoryBalance[3];
-            	// float max		= factoryBalance[4];
+		float balance   = factoryBalance[0];
+		Float refitFlag = factoryBalance[1];
             	String indStr = "";
-            	boolean rightAmount;
-            	if (balance == null)
-            		rightAmount = false;
-            	else {
-            		indStr	= df1.format(Math.abs(balance));
-            		rightAmount	= (balance == 0);
-            	}
+		boolean rightAmount = (balance == 0);
             	boolean warning = !rightAmount && !colony.isGovernor();
             	if (warning) {
-            		if (balance == null) {
-                 		indStr = text("MAIN_COLONY_SPENDING_REFIT");
-                 		g.setColor(Color.LIGHT_GRAY);
-            		}
-            		else if (balance > 0) {
-                		indStr = text("MAIN_COLONY_SPENDING_UNUSED_FACT", df1.format(balance));
-                		g.setColor(Color.ORANGE);
-                		g.fill(fillRect);
-    	            	g.setColor(Color.GRAY);
+			if (balance > 0) {
+				indStr = text("MAIN_COLONY_SPENDING_UNUSED_FACT", df1.format(balance));
+				g.setColor(Color.ORANGE);
+				g.fill(fillRect);
+				g.setColor(Color.GRAY);
                 	}
                 	else {
-                		indStr = text("MAIN_COLONY_SPENDING_NEEDED_FACT", df1.format(-balance));
-    	            	g.setColor(Color.LIGHT_GRAY);
+				indStr = text("MAIN_COLONY_SPENDING_NEEDED_FACT", df1.format(-balance));
+				g.setColor(Color.LIGHT_GRAY);
                 	}
+			if (refitFlag == null)
+				indStr = text("MAIN_COLONY_SPENDING_REFIT") + " " + indStr;
 	            	g.setFont(narrowFont(14));
 	            	int sw1 = g.getFontMetrics().stringWidth(indStr);
 	            	int x1 = (boxW-sw1)/2;


### PR DESCRIPTION
As mentioned on discord:
Changes industry spending slider to display "refit + needed/over" instead of just "refit".
Includes bugfixes for maxRobotControls in both factoryBalance() and spendingNeeded() in ColonyIndustry.
